### PR TITLE
Rename inline-styles-that-work to aphrodite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Inline Styles that Work
+# Aphrodite: Inline Styles that work
 
 Support for colocating your styles with your React component.
 
@@ -16,7 +16,7 @@ Support for colocating your styles with your React component.
 # API
 
     import React, { Component } from 'react';
-    import StyleSheet, { css } from 'inline-styles-that-work';
+    import { StyleSheet, css } from 'aphrodite';
 
     class App extends Component {
         render() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inline-styles-that-work",
+  "name": "aphrodite",
   "version": "0.0.1",
   "description": "Inline styles in JS that just work (TM)",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -29,22 +29,25 @@ const StyleSheet = {
                 _definition: val
             }];
         });
-    },
-
-    css: (function() {
-        const classNameAlreadyInjected = {};
-        return (styleDefinitions) => {
-            const className = styleDefinitions.map(s => s._name).join("-o_O-");
-            if (!classNameAlreadyInjected[className]) {
-                const generated = generateCSS(
-                    `.${className}`,
-                    styleDefinitions.map(d => d._definition));
-                injectStyles(generated);
-                classNameAlreadyInjected[className] = true;
-            }
-            return className;
-        }
-    })()
+    }
 };
 
-export default StyleSheet;
+const css = (function() {
+    const classNameAlreadyInjected = {};
+    return (styleDefinitions) => {
+        const className = styleDefinitions.map(s => s._name).join("-o_O-");
+        if (!classNameAlreadyInjected[className]) {
+            const generated = generateCSS(
+                `.${className}`,
+                styleDefinitions.map(d => d._definition));
+            injectStyles(generated);
+            classNameAlreadyInjected[className] = true;
+        }
+        return className;
+    }
+})();
+
+export default {
+    StyleSheet,
+    css
+};

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -3,7 +3,7 @@
 import {assert} from 'chai';
 import jsdom from 'jsdom';
 
-import StyleSheet from '../src/index.js';
+import { StyleSheet, css } from '../src/index.js';
 
 describe('create', () => {
     it('assigns a name to stylesheet properties', () => {
@@ -55,7 +55,7 @@ describe('css', () => {
 
             global.document = window.document;
 
-            assert.ok(StyleSheet.css([sheet.red, sheet.blue]));
+            assert.ok(css([sheet.red, sheet.blue]));
 
             done();
         });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,9 +6,8 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'inline-styles-that-work.js',
-    library: "StyleSheet",
-    libraryTarget: "umd"
+    filename: 'aphrodite.js',
+    libraryTarget: "commonjs2"
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Summary:
Do the rename! Also, export both `StyleSheet` and `css` as
properties from the main bundle, so we don't have to do

```
var StyleSheet = require("aphrodite");
var css = StyleSheet.css;
```

but now

```
var { StyleSheet, css } = require("aprodite");
```

Note that I didn't change the github repo URL in package.json nor
actually move the repo.

Test Plan:
- `npm run test`

Reviewers: @jlfwong
