### PR TITLE
Filter out falsy values so the `css` interface is nicer.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,15 @@ const StyleSheet = {
 const css = (function() {
     const classNameAlreadyInjected = {};
     return (styleDefinitions) => {
-        const className = styleDefinitions.map(s => s._name).join("-o_O-");
+        // Filter out falsy values from the input, to allow for
+        // `css([a, test && c])`
+        const validDefinitions = styleDefinitions.filter((def) => def);
+
+        const className = validDefinitions.map(s => s._name).join("-o_O-");
         if (!classNameAlreadyInjected[className]) {
             const generated = generateCSS(
                 `.${className}`,
-                styleDefinitions.map(d => d._definition));
+                validDefinitions.map(d => d._definition));
             injectStyles(generated);
             classNameAlreadyInjected[className] = true;
         }

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -60,4 +60,23 @@ describe('css', () => {
             done();
         });
     });
+
+    it('filters out falsy inputs', (done) => {
+        const sheet = StyleSheet.create({
+            red: {
+                color: 'red',
+            },
+        });
+
+        jsdom.env('<html><head></head></html>', (err, window) => {
+            assert.ok(!err);
+
+            global.document = window.document;
+
+            assert.equal(css([sheet.red]), css([sheet.red, false]));
+            assert.equal(css([sheet.red]), css([false, sheet.red]));
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Summary: A common pattern for inline styles is `style={{ ...base,
...test && override }}`. This adds the ability to do the  analagous
`className={css([base, test && override])}`.

Test plan:
- `npm run test`

Reviewers: @jlfwong
