### PR TITLE
💖Emoji Separators 💖

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const css = (function() {
             return "";
         }
 
-        const className = validDefinitions.map(s => s._name).join("-o_O-");
+        const className = validDefinitions.map(s => s._name).join("\u{1F496}");
         if (!classNameAlreadyInjected[className]) {
             const generated = generateCSS(
                 `.${className}`,


### PR DESCRIPTION
It turns out I was wrong! CSS selectors are totally allowed to contain unicode characters!

http://www.w3.org/TR/CSS21/syndata.html#tokenization

![image](https://github-cloud.s3.amazonaws.com/assets/150329/10566145/8b79248c-7593-11e5-81cc-6556c30f26ef.png)

If we wanted to be more byte-frugal, we could also use `\:` or `\+`, since escape sequences are also allowed.
