### PR TITLE
Add browserify settings to package.json -_-

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",
     "webpack": "^1.12.2"
+  },
+  "browserify": {
+    "transform": ["babelify"]
   }
 }


### PR DESCRIPTION
This is gross and I don't like it, but Browserify doesn't transform node_modules by default. We use Browserify at Spring and this lib needs to run through Babel since it's ES6. I think it's ok to add this to `package.json`, since it won't affect non-Browserify users and it will make the lib work with browserify, so long as the user has the Babelify transform.