### PR TITLE
remove need for `StyleSheet.create`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,17 +6,6 @@ import {
 } from './inject';
 
 const StyleSheet = {
-    create(sheetDefinition) {
-        return mapObj(sheetDefinition, ([key, val]) => {
-            return [key, {
-                // TODO(emily): Make a 'production' mode which doesn't prepend
-                // the class name here, to make the generated CSS smaller.
-                _name: `${key}_${hashObject(val)}`,
-                _definition: val
-            }];
-        });
-    },
-
     rehydrate(renderedClassNames=[]) {
         addRenderedClassNames(renderedClassNames);
     },
@@ -49,9 +38,9 @@ const css = (...styleDefinitions) => {
         return "";
     }
 
-    const className = validDefinitions.map(s => s._name).join("-o_O-");
-    injectStyleOnce(className, `.${className}`,
-        validDefinitions.map(d => d._definition));
+    const className = validDefinitions.map(s => `_${hashObject(s)}`).join(
+        "-o_O-");
+    injectStyleOnce(className, `.${className}`, validDefinitions);
 
     return className;
 };


### PR DESCRIPTION
It seems to me that the `StyleSheet.create` api is unnecessary.  

Removing it would (among other things) simplify the api, and minimize the hassle for users considering moving over from libraries like [radium](https://github.com/FormidableLabs/radium) for example, where there are no calls to `StyleSheet.create` as far as the library user is concerned.

So far, this PR only contains the rather small changes to `src/index.js` needed to make things work without the call to `StyleSheet.create`.  

I'm happy to fix up the (currently failing) test suite etc., but figured I would run the idea by you all before getting too far ahead.  After all, perhaps I'm missing some bigger picture, and `StyleSheet.create` is actually a good thing.

But it seems like it's totally not needed.

One thing to note is that these changes make it more difficult to track down the generated CSS class from your JS styles object (since the generated class name is no longer prefixed by the JS styles object key).