### PR TITLE
Upgrade to Babel 6 and remove default from export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": ["es2015"],
+    "plugins": [
+        "transform-object-rest-spread",
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register tests",
-    "test:watch": "mocha --watch --compilers js:babel/register tests",
+    "test": "mocha --compilers js:babel-core/register tests",
+    "test:watch": "mocha --watch --compilers js:babel-core/register tests",
     "build": "webpack --config webpack.config.js",
     "build:watch": "webpack --watch --config webpack.config.js",
     "prepublish": "babel -d lib/ src"
@@ -26,9 +26,12 @@
   },
   "homepage": "https://github.com/Khan/aphrodite",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
+    "babel": "^6.5.2",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
     "chai": "^3.3.0",
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ const css = (...styleDefinitions) => {
     return className;
 };
 
-export default {
+export {
     StyleSheet,
     StyleSheetServer,
     css,


### PR DESCRIPTION
Since the recent code changes when adding prefix styles, when running `npm prepublish` Babel was crashing on this line https://github.com/Khan/aphrodite/blob/master/src/util.js#L29 since it expects a plugin to be able to transpile said code.

As a consequence, the build published to NPM failed to contain the latest `/lib` files, if you right now install version `0.1.2` of aphrodite via NPM it will not be the latest according to what's on Github although the package.json version number indicates so (one good hint is the outdated README.md and complete lack of auto-prefixing code which is what made me investigate this problem)

With this PR I've added the necessary Babel plugin and a .babelrc file, so running `npm run prepublish` works as expected. the last step is to publish a new version to NPM so everyone has, for sure, the latest version of aphrodite including prefixed styles magic!
