### PR TITLE
Add keyframes support

### DIFF
--- a/examples/src/StyleTester.js
+++ b/examples/src/StyleTester.js
@@ -36,7 +36,8 @@ const StyleTester = React.createClass({
             <span className={css(styles.red, styles2.red)}>This should be green.</span>,
             <span className={css(this.state.timer ? styles.red : styles.blue)}>This should alternate between red and blue every second.</span>,
             <a href="javascript: void 0" className={css(styles.pseudoSelectors)}>This should turn red on hover and ???? (blue or red) on active</a>,
-            <div className={css(styles.flexCenter)}><div className={css(styles.flexInner)}>This should be centered inside the outer box, even in IE 10.</div></div>
+            <div className={css(styles.flexCenter)}><div className={css(styles.flexInner)}>This should be centered inside the outer box, even in IE 10.</div></div>,
+            <span className={css(styles.animate)}>This should animate</span>,
         ];
 
         return <div>
@@ -45,6 +46,16 @@ const StyleTester = React.createClass({
     },
 });
 
+
+const keyframes = {
+    'from': {
+        marginLeft: 0,
+    },
+
+    'to': {
+        marginLeft: 100,
+    },
+};
 
 const styles = StyleSheet.create({
     red: {
@@ -126,6 +137,12 @@ const styles = StyleSheet.create({
         width: 100,
         textAlign: "justify",
         textAlignLast: "justify",
+    },
+
+    animate: {
+        animationName: keyframes,
+        animationDuration: '2s',
+        animationIterationCount: 'infinite',
     },
 });
 

--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -202,3 +202,65 @@ describe('injection', () => {
         });
     });
 });
+
+describe('String handlers', () => {
+    beforeEach(() => {
+        global.document = jsdom.jsdom();
+        reset();
+    });
+
+    afterEach(() => {
+        global.document.close();
+        global.document = undefined;
+    });
+
+    describe('animationName', () => {
+        it('leaves plain strings alone', () => {
+            const sheet = StyleSheet.create({
+                animate: {
+                    animationName: "boo",
+                },
+            });
+
+            startBuffering();
+            css(sheet.animate);
+            flushToStyleTag();
+
+            const styleTags = global.document.getElementsByTagName("style");
+            const styles = styleTags[0].textContent;
+
+            assert.include(styles, 'animation-name:boo !important');
+        });
+
+        it('generates css for keyframes', () => {
+            const sheet = StyleSheet.create({
+                animate: {
+                    animationName: {
+                        'from': {
+                            left: 10,
+                        },
+                        '50%': {
+                            left: 20,
+                        },
+                        'to': {
+                            left: 40,
+                        },
+                    },
+                },
+            });
+
+            startBuffering();
+            css(sheet.animate);
+            flushToStyleTag();
+
+            const styleTags = global.document.getElementsByTagName("style");
+            const styles = styleTags[0].textContent;
+
+            assert.include(styles, '@keyframes keyframe_1ptfkz1');
+            assert.include(styles, 'from{left:10px;}');
+            assert.include(styles, '50%{left:20px;}');
+            assert.include(styles, 'to{left:40px;}');
+            assert.include(styles, 'animation-name:keyframe_1ptfkz1');
+        });
+    });
+});


### PR DESCRIPTION
Summary: This adds support for keyframes using the same mechanism that
we support `font-family` with. By passing in an object of keyframes as
the value of `animationName`, this will generate an `@keyframes` block
and return the name.

Test Plan:
 - `npm run test`
 - Visit the examples page at http://localhost:4114/, see that the "This
   should animate" text animates.
 - Visit the ssr examples page at http://localhost:4114/ssr,
   see the text still animates.

@jeresig @jlfwong