### PR TITLE
Make "!important" optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,31 @@ const styles = StyleSheet.create({
 
 Aphrodite will ensure that the global `@font-face` rule for this font is only inserted once, no matter how many times it's referenced.
 
+# Removing `!important`
+
+By default, Aphrodite will place `!important` on every CSS rule that it generates (see [here](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#The_!important_exception) for information on what `!important` does).  To opt out of this, simply import the `unimportantCss` function rather than `css`.
+
+```js
+import React, { Component } from 'react';
+import { StyleSheet, unimportantCss } from 'aphrodite';
+
+class App extends Component {
+    render() {
+        return <div>
+            <span className={unimportantCss(styles.red)}>
+                This is red.
+            </span>
+        </div>;
+    }
+}
+
+const styles = StyleSheet.create({
+    red: {
+        backgroundColor: 'red'
+    },
+});
+```
+
 # Caveats
 
 ## Assigning a string to a content property for a pseudo-element

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const StyleSheetServer = {
     },
 };
 
-const css = (...styleDefinitions) => {
+const createCssFn = (useImportant) => (...styleDefinitions) => {
     // Filter out falsy values from the input, to allow for
     // `css(a, test && c)`
     const validDefinitions = styleDefinitions.filter((def) => def);
@@ -51,7 +51,7 @@ const css = (...styleDefinitions) => {
 
     const className = validDefinitions.map(s => s._name).join("-o_O-");
     injectStyleOnce(className, `.${className}`,
-        validDefinitions.map(d => d._definition));
+        validDefinitions.map(d => d._definition), useImportant);
 
     return className;
 };
@@ -59,5 +59,6 @@ const css = (...styleDefinitions) => {
 export default {
     StyleSheet,
     StyleSheetServer,
-    css,
+    css: createCssFn(),
+    unimportantCss: createCssFn(false),
 };


### PR DESCRIPTION
Not yet ready for merge.

Looking for feedback :)

In https://github.com/Khan/aphrodite/issues/25, @xymostech [mentioned](https://github.com/Khan/aphrodite/issues/25#issuecomment-206466958) adding an api like

```js
StyleSheet.create({
    ...
}, { important: false });
```

which sounded good to me.  

However, the actual CSS is not generated at the call to `StyleSheet.create`, but rather at the call to `css`.  Thus I thought it made more sense for the `!important` option to be provided at the call to `css`. (Open to other ideas on this though.)

Since `css` is variadic, I exported another function `unimportantCss` (open to better name) which does exactly what `css` does, but doesn't add `!important` to the CSS it generates.