### PR TITLE
enable non-commonjs consumers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'aphrodite.js',
-    libraryTarget: "commonjs2"
+    libraryTarget: 'umd',
+    library: 'aphrodite'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
By choosing `umd` as the `libraryTarget`, people can use `aphrodite` without a bundler which is great for adoption. Note: people can continue using `CommonJS`. This is not a breaking change :-)