### PR TITLE
improve npm scripts and add more builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-dist/aphrodite.js -diff
+dist/* -diff

--- a/package.json
+++ b/package.json
@@ -11,9 +11,18 @@
   "scripts": {
     "test": "mocha --compilers js:babel/register tests",
     "test:watch": "mocha --watch --compilers js:babel/register tests",
-    "build": "webpack --config webpack.config.js",
-    "build:watch": "webpack --watch --config webpack.config.js",
-    "prepublish": "babel -d lib/ src"
+    "prebuild": "rimraf dist lib",
+    "build": "npm-run-all --parallel build:*",
+    "watch:build": "npm-run-all --parallel watch:build:*",
+    "build:main": "babel -d lib/ src",
+    "watch:build:main": "npm run build:main -- --watch",
+    "build:umd": "webpack --output-library-target umd --output-library aphrodite --output-filename aphrodite.umd.js --devtool source-map",
+    "watch:build:umd": "npm run build:umd -- --watch",
+    "build:umdmin": "webpack --output-library-target umd --output-library aphrodite --output-filename aphrodite.umd.min.js -p --devtool source-map",
+    "watch:build:umdmin": "npm run build:umdmin -- --watch",
+    "build:commonjs": "webpack --output-library-target commonjs2 --output-filename aphrodite.js",
+    "watch:build:commonjs": "npm run build:commonjs -- --watch",
+    "release": "npm run build && npm publish"
   },
   "repository": {
     "type": "git",
@@ -32,6 +41,8 @@
     "chai": "^3.3.0",
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",
+    "npm-run-all": "^1.7.0",
+    "rimraf": "^2.5.2",
     "webpack": "^1.12.2"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,7 @@ module.exports = {
     './src/index'
   ],
   output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'aphrodite.js',
-    libraryTarget: "commonjs2"
+    path: path.join(__dirname, 'dist')
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Here's how things work now with this PR:

1. There are 4 builds:
  - `main` uses babel and is what the package.json main points to. This
    is pretty much the same as before
  - `umd` uses webpack and specifies that the output should use UMD and
    it outputs a sourcemap file as well.
  - `umdmin` is the same as `umd` except it's run in webpack production
    mode (minified)
  - `commonjs` is exactly as it was before, a bundled module exported as
    a CommonJS module
2. There is a `watch` script associated with each of these
3. There is a `build` script which runs all the builds in parallel
4. There is a `watch:build` script which runs all the builds in watch
   mode in parallel
5. The `prepublish` script was removed because it's not doing what you
   probably think it's doing: (https://github.com/npm/npm/issues/3059)
   and we now have a `release` script which runs the build first and
   then runs `npm publish`. Just run `npm run release` instead of
   `npm publish`.
6. `.gitattributes` now excludes everything in `dist` from `diff`
   because we now have several files exporting there

That's it! Here's a gif showing this in action:

![aphrodite](https://cloud.githubusercontent.com/assets/1500684/14541525/980599ba-0247-11e6-9839-e453cff253a0.gif)
