### PR TITLE
Add support for descendant selectors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,45 @@ const styles = StyleSheet.create({
 
 Aphrodite will ensure that the global `@font-face` rule for this font is only inserted once, no matter how many times it's referenced.
 
+# Descendant selectors
+
+Descendant rules (i.e. a rule like `.parent:hover .child { ... }` in CSS) are created by adding values to your styles indicating the styles to apply to the child. To distinguish the styles from normal CSS keys, the keys start with a `>>`, like `'>>child'`.
+
+```js
+const styles = StyleSheet.create({
+    someContainer: {
+        ":hover": {
+            ">>myChild": {
+                // Styles to apply to the child when the parent is
+                // hovered over.
+                color: "red",
+                fontWeight: "bold"
+            }
+        }
+    }
+});
+```
+
+Then, apply the `someContainer` style using `css(styles.someContainer)`, and add the child's style to a descendant of the parent using `css(styles.someContainer.myChild)`, where `myChild` is the name of the key you used, without the `>>`.
+
+For example, using React's jsx syntax:
+
+```jsx
+<div className={css(styles.someContainer, ...)}>
+    <div className={css(styles.someContainer.myChild, ...)}>
+        This turns red and bold when the parent is hovered over
+    </div>
+</div>
+```
+
+This will generate CSS that looks like:
+```css
+.someContainer_xxx:hover .myChild_xxx {
+    color: red;
+    font-weight: bold;
+}
+```
+
 # Caveats
 
 ## Assigning a string to a content property for a pseudo-element

--- a/examples/src/StyleTester.js
+++ b/examples/src/StyleTester.js
@@ -38,6 +38,8 @@ const StyleTester = React.createClass({
             <a href="javascript: void 0" className={css(styles.pseudoSelectors)}>This should turn red on hover and ???? (blue or red) on active</a>,
             <div className={css(styles.flexCenter)}><div className={css(styles.flexInner)}>This should be centered inside the outer box, even in IE 10.</div></div>,
             <span className={css(styles.animate)}>This should animate</span>,
+            <span className={css(styles.hoverbase, styles.hoverextra)}>Hover over me and <span className={css(styles.red, styles.hoverbase.hoverchild)}>this (which should start green) should turn blue</span>
+            </span>,
         ];
 
         return <div>
@@ -143,6 +145,20 @@ const styles = StyleSheet.create({
         animationName: keyframes,
         animationDuration: '2s',
         animationIterationCount: 'infinite',
+    },
+
+    hoverbase: {
+        ':hover': {
+            '>>hoverchild': {
+                color: 'blue',
+            },
+        },
+    },
+
+    hoverextra: {
+        '>>hoverchild': {
+            color: 'green',
+        },
     },
 });
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -2,24 +2,150 @@ import prefixAll from 'inline-style-prefix-all';
 
 import {
     objectToPairs, kebabifyStyleName, recursiveMerge, stringifyValue,
-    importantify
+    importantify, uniquify, mapObj,
 } from './util';
 
-export const generateCSS = (selector, styleTypes, stringHandlers,
-        useImportant) => {
-    const merged = styleTypes.reduce(recursiveMerge);
+/**
+ * Generate a map from descendant selector names to all of the classnames that
+ * could be used for that selector.
+ *
+ * In StyleSheet.create, we add a special `_names` object to each place where a
+ * descendant style is used containing the classname associated with that
+ * descenant. Here, we traverse the styles and make a map from the descendant
+ * selectors to all of the classnames in those `_names` objects. (Since we
+ * merge together many styles that come out of StyleSheet.create, and we store
+ * the classnames as keys on the `_names` object, the classnames that we want
+ * all end up as keys on the final merged object.)
+ *
+ * For example, given styles looking like:
+ * ```
+ * {
+ *   ">>child": {
+ *     _names: { "parent1_child_x": true, "parent2_child_y": true },
+ *     color: "red"
+ *   },
+ *   ":hover": {
+ *     ">>child": {
+ *       _names: { "parent2_child_z": true },
+ *       color: "blue",
+ *     },
+ *     ">>otherchild": {
+ *       _names: { "parent1_otherchild_w": true },
+ *       color: "green"
+ *     }
+ *   }
+ * }
+ * ```
+ * this will generate the mapping
+ * ```
+ * {
+ *   ">>child": ["parent1_child_x", "parent2_child_y", "parent2_child_z"],
+ *   ">>otherchild": ["parent1_otherchild_w"]
+ * }
+ *
+ * @returns {Object.<string, string[]>}
+ */
+const findNamesForDescendants = (styles, names={}) => {
+    Object.keys(styles).forEach(key => {
+        if (key[0] === ':' || key[0] === '@') {
+            // Recurse for pseudo or @media styles
+            findNamesForDescendants(styles[key], names);
+        } else if (key[0] === '>' && key[1] === '>') {
+            // Recurse for descendant styles
+            findNamesForDescendants(styles[key], names);
 
+            // Pluck out all of the names in the _names object.
+            Object.keys(styles[key]._names).forEach(name => {
+                names[key] = names[key] || [];
+                names[key].push(name);
+            });
+        }
+    });
+
+    return names;
+};
+
+export const generateCSS = (selector, styleTypes, stringHandlers,
+                            useImportant) => {
+    const merged = styleTypes.reduce(recursiveMerge);
+    const classNamesForDescendant = findNamesForDescendants(merged);
+    const uniqueClassNamesForDescendant = mapObj(
+        classNamesForDescendant, ([k, v]) => [k, uniquify(v)]);
+
+    return generateCSSInner(
+        selector, merged, stringHandlers, useImportant,
+        uniqueClassNamesForDescendant);
+}
+
+/**
+ * Generate CSS for a selector and some styles.
+ *
+ * This function handles the media queries, pseudo selectors, and descendant
+ * styles that can be used in aphrodite styles. To actually generate the CSS,
+ * special-construct-less styles are passed to `generateCSSRuleset`.
+ *
+ * For instance, a call to
+ * ```
+ * generateCSSInner(".foo", {
+ *   color: "red",
+ *   "@media screen": {
+ *     height: 20,
+ *     ":hover": {
+ *       backgroundColor: "black"
+ *     }
+ *   },
+ *   ":active": {
+ *     fontWeight: "bold",
+ *     ">>bar": {
+ *       _names: { "foo_bar": true },
+ *       height: 10,
+ *     }
+ *   }
+ * }, ...);
+ * ```
+ * will make 5 calls to `generateCSSRuleset`:
+ * ```
+ * generateCSSRuleset(".foo", { color: "red" }, ...)
+ * generateCSSRuleset(".foo:active", { fontWeight: "bold" }, ...)
+ * generateCSSRuleset(".foo:active .foo_bar", { height: 10 }, ...)
+ * // These 2 will be wrapped in @media screen {}
+ * generateCSSRuleset(".foo", { height: 20 }, ...)
+ * generateCSSRuleset(".foo:hover", { backgroundColor: "black" }, ...)
+ * ```
+ *
+ * @param {string} selector: A base CSS selector for the styles to be generated
+ *     with.
+ * @param {Object} style: An object containing aphrodite styles to be
+ *     generated.
+ * @param stringHandlers: See `generateCSSRuleset`
+ * @param useImportant: See `generateCSSRuleset`
+ * @param {Object.<string, string[]>} classNamesForDescendant: A map from
+ *     descendent selectors in the styles to a list of classnames that are used
+ *     to identify that descendant. See `findNamesForDescendants`.
+ */
+const generateCSSInner = (selector, style, stringHandlers,
+                          useImportant, classNamesForDescendant) => {
     const declarations = {};
     const mediaQueries = {};
+    const descendants = {};
     const pseudoStyles = {};
 
-    Object.keys(merged).forEach(key => {
+    Object.keys(style).forEach(key => {
         if (key[0] === ':') {
-            pseudoStyles[key] = merged[key];
+            pseudoStyles[key] = style[key];
         } else if (key[0] === '@') {
-            mediaQueries[key] = merged[key];
+            mediaQueries[key] = style[key];
+        } else if (key[0] === '>' && key[1] === '>') {
+            // So we don't generate weird "_names: [Object object]" styles,
+            // pull the `_names` value out of the styles.
+            const { _names, ...stylesWithoutNames } = style[key];
+
+            descendants[key] = {
+                styles: stylesWithoutNames,
+                classNames: classNamesForDescendant[key],
+            };
         } else {
-            declarations[key] = merged[key];
+            declarations[key] = style[key];
         }
     });
 
@@ -27,14 +153,26 @@ export const generateCSS = (selector, styleTypes, stringHandlers,
         generateCSSRuleset(selector, declarations, stringHandlers,
             useImportant) +
         Object.keys(pseudoStyles).map(pseudoSelector => {
-            return generateCSSRuleset(selector + pseudoSelector,
-                                      pseudoStyles[pseudoSelector],
-                                      stringHandlers, useImportant);
+            return generateCSSInner(
+                selector + pseudoSelector, pseudoStyles[pseudoSelector],
+                stringHandlers, useImportant, classNamesForDescendant);
         }).join("") +
         Object.keys(mediaQueries).map(mediaQuery => {
-            const ruleset = generateCSS(selector, [mediaQueries[mediaQuery]],
-                stringHandlers, useImportant);
+            const ruleset = generateCSSInner(
+                selector, mediaQueries[mediaQuery], stringHandlers,
+                useImportant, classNamesForDescendant);
             return `${mediaQuery}{${ruleset}}`;
+        }).join("") +
+        Object.keys(descendants).map(key => {
+            // Since our child might have many different names, combine all of
+            // the possible selectors together with a comma.
+            const descendantSelector = descendants[key].classNames
+                .map(d => `${selector} .${d}`)
+                .join(",");
+
+            return generateCSSInner(
+                descendantSelector, descendants[key].styles,
+                stringHandlers, useImportant, classNamesForDescendant);
         }).join("")
     );
 };
@@ -55,6 +193,27 @@ const runStringHandlers = (declarations, stringHandlers) => {
     return result;
 };
 
+/**
+ * Generate a CSS ruleset with the selector and containing the declarations.
+ *
+ * This function assumes that the given declarations don't contain any special
+ * children (such as media queries, pseudo-selectors, or descendant styles).
+ *
+ * Example:
+ * ```
+ * generateCSSRuleset(".blah", { color: "red" });
+ * // -> ".blah{color: red !important;}"
+ * ```
+ *
+ * @param {string} selector: the selector associated with the ruleset
+ * @param {Object} declarations: a map from camelCased CSS property name to CSS
+ *     property value.
+ * @param {Object.<string, function>} stringHandlers: a map from camelCased CSS
+ *     property name to a function which will map the given value to the value
+ *     that is output.
+ * @param {bool} useImportant: A boolean saying whether to append "!important"
+ *     to each of the CSS declarations.
+ */
 export const generateCSSRuleset = (selector, declarations, stringHandlers,
         useImportant) => {
     const handledDeclarations = runStringHandlers(

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,43 @@ import {
     addRenderedClassNames, getRenderedClassNames
 } from './inject';
 
+// TODO(emily): Make a 'production' mode which doesn't prepend the class name
+// here, to make the generated CSS smaller.
+const makeClassName = (key, vals) => `${key}_${hashObject(vals)}`;
+
+// Find all of the references to descendant styles in a given definition,
+// generates a class name for each of them based on the class name of the
+// parent, and stores that name in a special `_names` object on the style.
+const findAndTagDescendants = (styles, base, names={}) => {
+    Object.keys(styles).forEach(key => {
+        if (key[0] === ':' || key[0] === '@') {
+            findAndTagDescendants(styles[key], base, names);
+        } else if (key[0] === '>' && key[1] === '>') {
+            findAndTagDescendants(styles[key], base, names);
+
+            const name = `${base}__${key.slice(2)}`;
+
+            names[key.slice(2)] = {
+                _isPlainClassName: true,
+                _className: name,
+            };
+
+            styles[key]._names = { [name]: true };
+        }
+    });
+
+    return names;
+};
+
 const StyleSheet = {
     create(sheetDefinition) {
         return mapObj(sheetDefinition, ([key, val]) => {
+            const name = makeClassName(key, val);
+
             return [key, {
-                // TODO(emily): Make a 'production' mode which doesn't prepend
-                // the class name here, to make the generated CSS smaller.
-                _name: `${key}_${hashObject(val)}`,
-                _definition: val
+                _name: name,
+                _definition: val,
+                ...findAndTagDescendants(val, name),
             }];
         });
     },
@@ -39,6 +68,8 @@ const StyleSheetServer = {
     },
 };
 
+const isPlainClassName = (def) => def._isPlainClassName;
+
 const css = (...styleDefinitions) => {
     // Filter out falsy values from the input, to allow for
     // `css(a, test && c)`
@@ -49,11 +80,23 @@ const css = (...styleDefinitions) => {
         return "";
     }
 
-    const className = validDefinitions.map(s => s._name).join("-o_O-");
-    injectStyleOnce(className, `.${className}`,
-        validDefinitions.map(d => d._definition));
+    // Filter out "plain class name" arguments, which just want us to add a
+    // classname to the end result, instead of generating styles.
+    const plainClassNames = validDefinitions.filter(isPlainClassName).map(def => def._className);
 
-    return className;
+    const otherDefinitions = validDefinitions.filter(
+        def => !isPlainClassName(def));
+
+    // If there are only plain class names, just join those.
+    if (otherDefinitions.length === 0) {
+        return plainClassNames.join(" ");
+    }
+
+    const className = otherDefinitions.map(s => s._name).join("-o_O-");
+    injectStyleOnce(className, `.${className}`,
+        otherDefinitions.map(d => d._definition));
+
+    return [className, ...plainClassNames].join(" ");
 };
 
 export default {

--- a/src/util.js
+++ b/src/util.js
@@ -12,6 +12,13 @@ const pairsToObject = (pairs) => {
 
 export const mapObj = (obj, fn) => pairsToObject(objectToPairs(obj).map(fn))
 
+// Removes duplicates from a list (only works for strings, non-destructive)
+export const uniquify = (list) => {
+    const set = {};
+    list.forEach(k => set[k] = true);
+    return Object.keys(set);
+};
+
 const UPPERCASE_RE = /([A-Z])/g;
 const MS_RE = /^ms-/;
 

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -128,4 +128,120 @@ describe('generateCSS', () => {
             display: 'flex',
         }], '.foo{display:-webkit-box !important;display:-moz-box !important;display:-ms-flexbox !important;display:-webkit-flex !important;display:flex !important;}');
     });
+
+    it('generates descendant styles', () => {
+        assertCSS('.foo', [{
+            color: 'red',
+            '>>blue': {
+                color: 'blue',
+                '>>green': {
+                    color: 'green',
+                    _names: {
+                        'foo__green': true,
+                    },
+                },
+                _names: {
+                    'foo__blue': true,
+                },
+            }
+        }], '.foo{color:red !important;}' +
+                  '.foo .foo__blue{color:blue !important;}' +
+                  '.foo .foo__blue .foo__green{color:green !important;}');
+    });
+
+    it('handles merging of descendant styles', () => {
+        assertCSS('.foo', [{
+            '>>blue': {
+                color: 'blue',
+                _names: {
+                    'foo_abcdef__blue': true,
+                },
+            },
+        }, {
+            '>>blue': {
+                color: 'green',
+                _names: {
+                    'foo_123456__blue': true,
+                },
+            },
+        }], '.foo .foo_abcdef__blue,' +
+                  '.foo .foo_123456__blue{color:green !important;}');
+    });
+
+    it('handles multiples of the same descendant name', () => {
+        assertCSS('.foo', [{
+            '>>blue': {
+                color: 'blue',
+                _names: {
+                    'foo__blue': true,
+                },
+            },
+            ':hover': {
+                '>>blue': {
+                    color: 'green',
+                    _names: {
+                        'foo__blue': true,
+                    },
+                },
+            },
+        }], '.foo:hover .foo__blue{color:green !important;}' +
+                  '.foo .foo__blue{color:blue !important;}');
+    });
+
+    it('handles merging and multiples for descenant styles', () => {
+        assertCSS('.foo', [{
+            '>>child': {
+                color: 'blue',
+                _names: {
+                    'foo_abcdef__child': true,
+                },
+            },
+            ':hover': {
+                '>>child': {
+                    color: 'green',
+                    _names: {
+                        'foo_abcdef__child': true,
+                    },
+                },
+            },
+        }, {
+            ':hover': {
+                '>>child': {
+                    color: 'red',
+                    _names: {
+                        'foo_123456__child': true,
+                    },
+                },
+            },
+        }], '.foo:hover .foo_abcdef__child,' +
+                  '.foo:hover .foo_123456__child{color:red !important;}' +
+                  '.foo .foo_abcdef__child,' +
+                  '.foo .foo_123456__child{color:blue !important;}');
+    });
+
+    it('generates descendant styles with @media queries', () => {
+        assertCSS('.foo', [{
+            '@media screen': {
+                '>>blue': {
+                    color: 'blue',
+                    _names: {
+                        'foo__blue': true,
+                    },
+                }
+            }
+        }], '@media screen{.foo .foo__blue{color:blue !important;}}');
+    });
+
+    it('generates descendant styles with pseudo-styles', () => {
+        assertCSS('.foo', [{
+            ':hover': {
+                '>>blue': {
+                    color: 'blue',
+                    _names: {
+                        'foo__blue': true,
+                    },
+                }
+            }
+        }], '.foo:hover .foo__blue{color:blue !important;}');
+    });
 });


### PR DESCRIPTION
Summary: This adds support for doing descendant style selection; that is,
changing child component styles based on the state/existence of a parent. This
selection in particularly useful when combined with the use of pseudo-classes,
by generating styles that look like `.parent:hover .child`, so the child styles
can depend on the active state of the parent.

Fixes #10

An example of the syntax that is added in this commit (and an example for the
explanation in this commit message):

```js
const styles = StyleSheet.create({
    parent: {
        '>>child': {
            color: "red"
        },
        ':hover': {
            '>>child': {
                color: "blue"
            },
            '>>otherchild': {
                color: "white"
            }
        },
    },

    altparent: {
        ':hover': {
            '>>child': {
                color: "green"
            }
        }
    }
});
```

It turns out that the API for aphrodite doesn't play well with descendent
styles. In particular, it's difficult to let *descendants have unique
classnames* for themselves, at the same time as allowing *merging between
styles which contain descendant selectors*.

This pull request attempts to do both of these things. The code is a bit messy,
so I'll lay out what's going on in this pull request. Please ask questions, if
something is confusing! The Aphrodite code is nice because it's all fairly
easily understood, and I'm afraid that this adding too much complexity.

The basic flow of this diff is:

1. In `StyleSheet.create`, we recurse through the passed-in styles, and find
each of the descendant selectors (which have keys that look like `>>blah`). In
the example above, it would find `parent['>>child']`,
`parent[':hover']['>>child']`, `parent[':hover']['>>otherchild']`, and
`altparent[':hover']['>>child']`. In each place, we:
  - generate a class name for that descendant selector. This is based on the
    class name of the parent class, as well as the key name.

    For example, if the class name for `styles.parent` was `parent_abcdef`, we
    might generate the class name `parent_abcdef__child` for `parent['>>child']`.

  - tag the style by adding a `_names` object, with the class name as a key of
    the object.

    For example, `parent['>>child']` would end up looking like `{ color: "red",
    _names: { parent_abcdef__child: true } }`.

  - collect a map of each of the keys (without the `>>` bit) to their class
    names.

    For example, for `styles.parent`, we would generate a map that looks like
    `{ child: "parent_abcdef__child", otherchild: "parent_abcdef__otherchild"
    }`.
We merge in the map from key to class name into the generated style, so that
the class names can be accessed using a syntax like `styles.parent.child`.

2. When *parent* styles are passed into `css()`, their styles are merged
together. If one style overrides another's descendant styling, the `_names`
object will be merged together and will contain all of the associated class
names.  
For example, when evaluating `css(styles.parent, styles.altparent)`, we would
end up with merged styles looking like:
    ```
    {
        '>>child': {
            color: "red",
            _names: { parent_abcdef__child: true },
        },
        ':hover': {
            '>>child': {
                color: "green",
                _names: {
                    parent_abcdef__child: true,
                    altparent_123456__child: true,
                },
            },
            '>>otherchild': {
                color: "white",
                _names: { parent_abcdef__otherchild: true },
            }
        }
    }
    ```
We then generate a map from the descendent keys to all of the class names that
could be associated with a given key by recursing and looking at each of the
`_names` objects. For example, the map would look like:
    ```
    {
        '>>child': ["parent_abcdef__child", "altparent_123456__child"],
        '>>otherchild': ["parent_abcdef__otherchild"]
    }
    ```
When generating the styles, we look at this map and then generate styles for
each of the classnames listed. This is so that these styles will match up with
uses of both `css(styles.parent.child)` and `css(styles.altparent.child)`.
For example, when generating the `style[':hover']['>>child']` styles, we
generate:
    ```
    .parent_abcdef-o_O-altparent_123456:hover .parent_abcdef__child { ... }
    .parent_abcdef-o_O-altparent_123456:hover .altparent_123456__child { ... }
    ```

3. When *descendant* styles are passed into `css()`, like
`css(styles.parent.child)`, we simply return the associated class name (in this
case, `"parent_abcdef__child"`) in the output.

Test Plan:
 - `npm run test`
 - `cd examples && npm run examples`, then visit http://localhost:4114/ and see
   that the last line starts green and when "Hover over me" is hovered, the
   other part turns blue.

@zgotsch @jlfwong @kentcdodds @montemishkin 