### PR TITLE
Upgrade prefixer, don't handle multiple rules at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   },
   "dependencies": {
     "asap": "^2.0.3",
-    "inline-style-prefix-all": "1.0.5"
+    "inline-style-prefix-all": "^2.0.0"
   }
 }

--- a/src/generate.js
+++ b/src/generate.js
@@ -64,7 +64,7 @@ export const generateCSSRuleset = (selector, declarations, stringHandlers,
 
     const prefixedRules = flatten(
         objectToPairs(prefixedDeclarations).map(([key, value]) => {
-            if (typeof value === 'object') {
+            if (Array.isArray(value)) {
                 // inline-style-prefix-all returns an array when there should be
                 // multiple rules, we will flatten to single rules
                 return value.map(v => [key, v]);

--- a/src/generate.js
+++ b/src/generate.js
@@ -2,7 +2,7 @@ import prefixAll from 'inline-style-prefix-all';
 
 import {
     objectToPairs, kebabifyStyleName, recursiveMerge, stringifyValue,
-    importantify
+    importantify, flatten
 } from './util';
 
 export const generateCSS = (selector, styleTypes, stringHandlers,
@@ -62,7 +62,18 @@ export const generateCSSRuleset = (selector, declarations, stringHandlers,
 
     const prefixedDeclarations = prefixAll(handledDeclarations);
 
-    const rules = objectToPairs(prefixedDeclarations).map(([key, value]) => {
+    const prefixedRules = flatten(
+        objectToPairs(prefixedDeclarations).map(([key, value]) => {
+            if (typeof value === 'object') {
+                // inline-style-prefix-all returns an array when there should be
+                // multiple rules, we will flatten to single rules
+                return value.map(v => [key, v]);
+            }
+            return [[key, value]];
+        })
+    );
+
+    const rules = prefixedRules.map(([key, value]) => {
         const stringValue = stringifyValue(key, value);
         const ret = `${kebabifyStyleName(key)}:${stringValue};`;
         return useImportant === false ? ret : importantify(ret);

--- a/src/generate.js
+++ b/src/generate.js
@@ -67,7 +67,24 @@ export const generateCSSRuleset = (selector, declarations, stringHandlers,
             if (Array.isArray(value)) {
                 // inline-style-prefix-all returns an array when there should be
                 // multiple rules, we will flatten to single rules
-                return value.map(v => [key, v]);
+
+                const prefixedValues = [];
+                const unprefixedValues = [];
+
+                value.forEach(v => {
+                  if (v.indexOf('-') === 0) {
+                    prefixedValues.push(v);
+                  } else {
+                    unprefixedValues.push(v);
+                  }
+                });
+
+                prefixedValues.sort();
+                unprefixedValues.sort();
+
+                return prefixedValues
+                  .concat(unprefixedValues)
+                  .map(v => [key, v]);
             }
             return [[key, value]];
         })

--- a/src/util.js
+++ b/src/util.js
@@ -180,14 +180,13 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object) => murmurhash2_32_gc(JSON.stringify(object));
 
 
-const IMPORTANT_RE = /^([^:]+:.*?)( !important)?$/;
+const IMPORTANT_RE = /^([^:]+:.*?)( !important)?;$/;
 
-// Given a style string like "a: b; c: d;", adds !important to each of the
-// properties to generate "a: b !important; c: d !important;".
-export const importantify = (string) => {
-    return string.split(";").map(
-        str => str.replace(
-            IMPORTANT_RE,
-            (_, base, important) => base + " !important")
-    ).join(";");
-};
+// Given a single style rule string like "a: b;", adds !important to generate
+// "a: b !important;".
+export const importantify = (string) =>
+    string.replace(
+        IMPORTANT_RE,
+        (_, base, important) => base + " !important;");
+
+export const flatten = (list) => list.reduce((memo, x) => memo.concat(x), []);

--- a/src/util.js
+++ b/src/util.js
@@ -12,6 +12,10 @@ const pairsToObject = (pairs) => {
 
 export const mapObj = (obj, fn) => pairsToObject(objectToPairs(obj).map(fn))
 
+// Flattens an array one level
+// [[A], [B, C, [D]]] -> [A, B, C, [D]]
+export const flatten = (list) => list.reduce((memo, x) => memo.concat(x), []);
+
 const UPPERCASE_RE = /([A-Z])/g;
 const MS_RE = /^ms-/;
 
@@ -188,5 +192,3 @@ export const importantify = (string) =>
     string.replace(
         IMPORTANT_RE,
         (_, base, important) => base + " !important;");
-
-export const flatten = (list) => list.reduce((memo, x) => memo.concat(x), []);

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -150,6 +150,6 @@ describe('generateCSS', () => {
     it('adds browser prefixes', () => {
         assertCSS('.foo', [{
             display: 'flex',
-        }], '.foo{display:-webkit-box !important;display:-moz-box !important;display:-webkit-flex !important;display:-ms-flexbox !important;display:flex !important;}');
+        }], '.foo{display:-moz-box !important;display:-ms-flexbox !important;display:-webkit-box !important;display:-webkit-flex !important;display:flex !important;}');
     });
 });

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -53,6 +53,24 @@ describe('generateCSSRuleset', () => {
             zIndex: 5
         }, '.foo{width:10px !important;z-index:5 !important;}');
     });
+
+    it("doesn't break content strings which contain semicolons during importantify", () => {
+        assertCSSRuleset('.foo', {
+            content: '"foo;bar"'
+        }, '.foo{content:"foo;bar" !important;}');
+    });
+
+    it("doesn't break quoted url() arguments during importantify", () => {
+        assertCSSRuleset('.foo', {
+            background: 'url("data:image/svg+xml;base64,myImage")'
+        }, '.foo{background:url("data:image/svg+xml;base64,myImage") !important;}');
+    });
+
+    it("doesn't break unquoted url() arguments during importantify", () => {
+        assertCSSRuleset('.foo', {
+            background: 'url(data:image/svg+xml;base64,myImage)'
+        }, '.foo{background:url(data:image/svg+xml;base64,myImage) !important;}');
+    });
 });
 describe('generateCSS', () => {
     const assertCSS = (className, styleTypes, expected, stringHandlers,
@@ -126,6 +144,6 @@ describe('generateCSS', () => {
     it('adds browser prefixes', () => {
         assertCSS('.foo', [{
             display: 'flex',
-        }], '.foo{display:-webkit-box !important;display:-moz-box !important;display:-ms-flexbox !important;display:-webkit-flex !important;display:flex !important;}');
+        }], '.foo{display:-webkit-box !important;display:-moz-box !important;display:-webkit-flex !important;display:-ms-flexbox !important;display:flex !important;}');
     });
 });

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -71,6 +71,12 @@ describe('generateCSSRuleset', () => {
             background: 'url(data:image/svg+xml;base64,myImage)'
         }, '.foo{background:url(data:image/svg+xml;base64,myImage) !important;}');
     });
+
+    it("doesn't importantify rules that are already !important", () => {
+        assertCSSRuleset('.foo', {
+            color: 'blue !important',
+        }, '.foo{color:blue !important;}');
+    });
 });
 describe('generateCSS', () => {
     const assertCSS = (className, styleTypes, expected, stringHandlers,


### PR DESCRIPTION
Use the new `inline-style-prefix-all`, which gives us a nice array of rules which need to be prefixed. Only importantify one rule at a time, so we don't have to parse css in order to pick the right semicolons :)

fixes #70 