### PR TITLE
Add code coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 node_modules
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register tests",
-    "test:watch": "mocha --watch --compilers js:babel/register tests",
+    "test": "npm run coverage",
+    "coverage": "nyc --check-coverage --lines 100 --branches 100 npm run tests",
+    "tests": "mocha --compilers js:babel/register tests",
+    "tests:watch": "mocha --watch --compilers js:babel/register tests",
     "prebuild": "rimraf dist lib",
     "build": "npm-run-all --parallel build:*",
     "watch:build": "npm-run-all --parallel watch:build:*",
@@ -42,6 +44,7 @@
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",
     "npm-run-all": "^1.7.0",
+    "nyc": "^6.4.4",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.2"
   },

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -254,6 +254,10 @@ describe('rehydrate', () => {
             done();
         });
     });
+
+    it('doesn\'t fail with no argument passed in', () => {
+        StyleSheet.rehydrate();
+    });
 });
 
 describe('StyleSheetServer.renderStatic', () => {

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,0 +1,30 @@
+import {assert} from 'chai';
+
+import {recursiveMerge} from '../src/util.js';
+
+describe('Utils', () => {
+    describe('recursiveMerge', () => {
+        it('merges two objects', () => {
+            assert.deepEqual(
+                recursiveMerge({
+                    a: 1,
+                }, {
+                    a: 2,
+                }),
+                {
+                    a: 2,
+                });
+
+            assert.deepEqual(
+                recursiveMerge({
+                    a: 1,
+                }, {
+                    b: 2,
+                }),
+                {
+                    a: 1,
+                    b: 2,
+                });
+        });
+    });
+});


### PR DESCRIPTION
This adds code coverage tests using [nyc](https://github.com/bcoe/nyc),
based on #51. This both makes the tests run code coverage, as well as
adding tests to get us up to 100% line and branch coverage!

Test Plan: `npm run test`

@jlfwong @kentcdodds