### PR TITLE
Try insertRule

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -23,20 +23,20 @@ export const generateCSS = (selector, styleTypes, stringHandlers,
         }
     });
 
-    return (
+    return [
         generateCSSRuleset(selector, declarations, stringHandlers,
-            useImportant) +
-        Object.keys(pseudoStyles).map(pseudoSelector => {
+            useImportant),
+        ...Object.keys(pseudoStyles).map(pseudoSelector => {
             return generateCSSRuleset(selector + pseudoSelector,
                                       pseudoStyles[pseudoSelector],
                                       stringHandlers, useImportant);
-        }).join("") +
-        Object.keys(mediaQueries).map(mediaQuery => {
+        }),
+        ...Object.keys(mediaQueries).map(mediaQuery => {
             const ruleset = generateCSS(selector, [mediaQueries[mediaQuery]],
                 stringHandlers, useImportant);
-            return `${mediaQuery}{${ruleset}}`;
-        }).join("")
-    );
+            return `${mediaQuery}{${ruleset.join('')}}`;
+        }),
+    ];
 };
 
 const runStringHandlers = (declarations, stringHandlers) => {

--- a/src/inject.js
+++ b/src/inject.js
@@ -32,11 +32,13 @@ const injectStyleTag = (cssContents) => {
         }
     }
 
-    if (styleTag.styleSheet) {
-        styleTag.styleSheet.cssText += cssContents;
-    } else {
-        styleTag.appendChild(document.createTextNode(cssContents));
-    }
+    return styleTag;
+
+    // if (styleTag.styleSheet) {
+    //     styleTag.styleSheet.cssText += cssContents;
+    // } else {
+    //     styleTag.appendChild(document.createTextNode(cssContents));
+    // }
 };
 
 // Custom handlers for stringifying CSS values that have side effects
@@ -96,7 +98,7 @@ const stringHandlers = {
         });
         finalVal += '}';
 
-        injectGeneratedCSSOnce(name, finalVal);
+        injectGeneratedCSSOnce(name, [finalVal]);
 
         return name;
     },
@@ -105,6 +107,7 @@ const stringHandlers = {
 // This is a map from Aphrodite's generated class names to `true` (acting as a
 // set of class names)
 let alreadyInjected = {};
+global.inj = alreadyInjected;
 
 // This is the buffer of styles which have not yet been flushed.
 let injectionBuffer = "";
@@ -130,7 +133,14 @@ const injectGeneratedCSSOnce = (key, generatedCSS) => {
             asap(flushToStyleTag);
         }
 
-        injectionBuffer += generatedCSS;
+        injectionBuffer += generatedCSS.join('');
+
+        const style = injectStyleTag();
+        const sheet = style.sheet;
+        for (const rule of generatedCSS) {
+          sheet.insertRule(rule, sheet.rules ? sheet.rules.length : 0);
+        }
+
         alreadyInjected[key] = true;
     }
 }

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -83,7 +83,7 @@ describe('generateCSS', () => {
             useImportant) => {
         const actual = generateCSS(className, styleTypes, stringHandlers,
             useImportant);
-        assert.equal(actual, expected.split('\n').map(x => x.trim()).join(''));
+        assert.equal(actual.join(''), expected.split('\n').map(x => x.trim()).join(''));
     };
 
     it('returns a CSS string for a single property', () => {


### PR DESCRIPTION
This PR is a demonstration of using `styleTag.sheet.insertRule` instead of `styleTag.appendChild` (#76). The code is probably bad, I just made a minimum amount of changes to show the `insertRule` approach. It's not intended to be merge, just to discuss :)

This way styles are applied immediately in the `css` function. So in `componentDidMount` and `componentDidUpdate` all styles are already applied.

Also this approach scales better as the app continues to work, because browser doesn't have to reparse all css.

Problems:
- `insertRule('::-moz-focus-inner {}', 0)` throws in chrome. If we wrap it with try-catch, we have about 25% performance penalty.
- This API doesn't exists on IE8. Does aphrodite support it?
