### PR TITLE
Replace npm run release script with hooks into npm version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
+dist/*.map
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "watch:build:umdmin": "npm run build:umdmin -- --watch",
     "build:commonjs": "webpack --output-library-target commonjs2 --output-filename aphrodite.js",
     "watch:build:commonjs": "npm run build:commonjs -- --watch",
-    "release": "npm run build && npm publish"
+    "preversion": "npm test",
+    "version": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So long as the version is always bumped via `npm version`, this ensures that npm
releases will always be published with all files in `dist/` up to date (which
I messed up with
0.3.2).

It seems the current proposed workflow (which I forgot) was to use `npm release`
instead of `npm publish` in order to accomplish something similar, but I think
this is slightly better, because now `version` does all the useful,
non-destructive actions in one shot (whereas `version` would still have to be
done separately with `npm release`).

Now the workflow for published a new version is as follows:

    npm version [major|minor|patch]
    git push
    npm publish

In the previous workflow, it was unclear to me where the commit should happen.
I suppose you would publish then commit and push? Publishing from unpushed
commits makes me a little uneasy.

This also gitignores the generated source maps, since I don't see a compelling reason for those to be published (I didn't change the build rules though, because I *do* see the value in that for development of aphrodite itself).

@xymostech @kentcdodds 