### PR TITLE
Add StyleSheetTestUtils module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,13 @@ const StyleSheetServer = {
     },
 };
 
+const StyleSheetTestUtils = {
+  startBufferingForTests() {
+    reset();
+    startBuffering();
+  },
+};
+
 const css = (...styleDefinitions) => {
     // Filter out falsy values from the input, to allow for
     // `css(a, test && c)`
@@ -59,5 +66,6 @@ const css = (...styleDefinitions) => {
 export default {
     StyleSheet,
     StyleSheetServer,
+    StyleSheetTestUtils,
     css,
 };

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -2,7 +2,7 @@ import asap from 'asap';
 import {assert} from 'chai';
 import jsdom from 'jsdom';
 
-import { StyleSheet, StyleSheetServer, css } from '../src/index.js';
+import { StyleSheet, StyleSheetServer, StyleSheetTestUtils, css } from '../src/index.js';
 import { reset } from '../src/inject.js';
 
 describe('css', () => {
@@ -342,5 +342,21 @@ describe('StyleSheetServer.renderStatic', () => {
 
         const newRet = StyleSheetServer.renderStatic(emptyRender);
         assert.equal(newRet.css.content, "");
+    });
+});
+
+describe('StyleSheetTestUtils.startBufferingForTests', () => {
+    const sheet = StyleSheet.create({
+        red: {
+            color: 'red',
+        },
+        blue: {
+            color: 'blue'
+        },
+    });
+
+    it('starts buffering', () => {
+        StyleSheetTestUtils.startBufferingForTests();
+        assert.doesNotThrow(() => css(sheet.red, sheet.blue));
     });
 });


### PR DESCRIPTION
Adds `StyleSheetTestUtils` module with `startBufferingForTests` method which enables
components using Aphrodite to render in a DOMless environment without throwing an exception.

For our use case, this allows us to use [Enzyme](https://github.com/airbnb/enzyme) to shallow render our Aphrodite-powered components in Mocha tests by running `StyleSheetTestUtils.startBufferingForTests()` in a global `beforeEach` hook so that our tests "just work" without needing to explicitly use the `renderStatic` method in every individual test.

Tests pass and maintain 100% coverage threshold. 