### PR TITLE
Introduce StyleSheetTestUtils to make writing tests for Aphrodite easier

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ const StyleSheet = {
     },
 };
 
+/**
+ * Utilities for using Aphrodite server-side.
+ */
 const StyleSheetServer = {
     renderStatic(renderFunc) {
         reset();
@@ -36,6 +39,36 @@ const StyleSheetServer = {
                 renderedClassNames: getRenderedClassNames(),
             },
         };
+    },
+};
+
+/**
+ * Utilities for using Aphrodite in tests.
+ *
+ * Not meant to be used in production.
+ */
+const StyleSheetTestUtils = {
+    /**
+     * Prevent styles from being injected into the DOM.
+     *
+     * This is useful in situations where you'd like to test rendering UI
+     * components which use Aphrodite without any of the side-effects of
+     * Aphrodite happening. Particularly useful for testing the output of
+     * components when you have no DOM, e.g. testing in Node without a fake DOM.
+     *
+     * Should be paired with a subsequent call to
+     * clearBufferAndResumeStyleInjection.
+     */
+    suppressStyleInjection() {
+        reset();
+        startBuffering();
+    },
+
+    /**
+     * Opposite method of preventStyleInject.
+     */
+    clearBufferAndResumeStyleInjection() {
+        reset();
     },
 };
 
@@ -59,5 +92,6 @@ const css = (...styleDefinitions) => {
 export default {
     StyleSheet,
     StyleSheetServer,
+    StyleSheetTestUtils,
     css,
 };

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -2,7 +2,12 @@ import asap from 'asap';
 import {assert} from 'chai';
 import jsdom from 'jsdom';
 
-import { StyleSheet, StyleSheetServer, css } from '../src/index.js';
+import {
+  StyleSheet,
+  StyleSheetServer,
+  StyleSheetTestUtils,
+  css
+} from '../src/index.js';
 import { reset } from '../src/inject.js';
 
 describe('css', () => {
@@ -342,5 +347,26 @@ describe('StyleSheetServer.renderStatic', () => {
 
         const newRet = StyleSheetServer.renderStatic(emptyRender);
         assert.equal(newRet.css.content, "");
+    });
+});
+
+describe('StyleSheetTestUtils.suppressStyleInjection', () => {
+    beforeEach(() => {
+        StyleSheetTestUtils.suppressStyleInjection();
+    });
+
+    afterEach(() => {
+        StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+    });
+
+    it('allows css to be called without requiring a DOM', (done) => {
+        const sheet = StyleSheet.create({
+            red: {
+                color: 'red',
+            },
+        });
+
+        css(sheet.red);
+        asap(done);
     });
 });


### PR DESCRIPTION
Imagine you're trying to introduce Aphrodite gradually into an existing codebase
that already has extensive test coverage for rendering components.

If those tests are run in node without any fake DOM being constructed, your
previously working tests will now fail with the following error:

     Error: Cannot automatically buffer without a document

The introduction of StyleSheetTestUtils makes it easy to suppress such problems
by preventing Aphrodite from trying to interact with the DOM at all.

The new API would be usable in your tests like so (using Mocha syntax for
demonstration purposes):

    import { StyleSheetTestUtils } from 'aphrodite';

    beforeEach(() => {
        StyleSheetTestUtils.suppressStyleInjection();
    });

    afterEach(() => {
        StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
    });

I intentionally did not expose an API returning CSS content here to allow us
flexibility to change the CSS formatting or class name generation without
considering it a breaking API change.

Meant to solve the problem presented in #90