### PR TITLE
Adding useImportant config

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -2,7 +2,7 @@ import prefixAll from 'inline-style-prefixer/static';
 
 import {
     objectToPairs, kebabifyStyleName, recursiveMerge, stringifyValue,
-    importantify, flatten
+    shouldUseImportant, importantify, flatten
 } from './util';
 /**
  * Generate CSS for a selector and some styles.
@@ -173,7 +173,7 @@ export const generateCSSRuleset = (selector, declarations, stringHandlers,
     const rules = prefixedRules.map(([key, value]) => {
         const stringValue = stringifyValue(key, value);
         const ret = `${kebabifyStyleName(key)}:${stringValue};`;
-        return useImportant === false ? ret : importantify(ret);
+        return shouldUseImportant(useImportant) ? importantify(ret) : ret;
     }).join("");
 
     if (rules) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {mapObj, hashObject, setConfig} from './util';
+import {mapObj, hashObject, setConfig, getConfig} from './util';
 import {
     injectStyleOnce,
     reset, startBuffering, flushToString,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {mapObj, hashObject} from './util';
+import {mapObj, hashObject, setConfig} from './util';
 import {
     injectStyleOnce,
     reset, startBuffering, flushToString,
@@ -93,5 +93,7 @@ export default {
     StyleSheet,
     StyleSheetServer,
     StyleSheetTestUtils,
+    setConfig,
+    getConfig,
     css,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -184,6 +184,18 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object) => murmurhash2_32_gc(JSON.stringify(object));
 
 
+const config = {
+    useImportant: false,
+};
+
+export const setConfig = (prop, val) => config[prop] = val;
+
+export const getConfig = (prop) => config[prop];
+
+export const shouldUseImportant = (useImportant) =>
+    !(!config.useImportant || useImportant === false);
+
+
 const IMPORTANT_RE = /^([^:]+:.*?)( !important)?;$/;
 
 // Given a single style rule string like "a: b;", adds !important to generate

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -79,6 +79,14 @@ describe('generateCSSRuleset', () => {
             color: 'blue !important',
         }, '.foo{color:blue !important;}');
     });
+
+    it("doesn't importantify rules when config.useImportant is false", () => {
+        setConfig('useImportant', false);
+        assertCSSRuleset('.foo', {
+            color: 'blue',
+        }, '.foo{color:blue;}');
+        setConfig('useImportant', true);
+    });
 });
 describe('generateCSS', () => {
     const assertCSS = (className, styleTypes, expected, stringHandlers,

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -1,8 +1,10 @@
 import {assert} from 'chai';
 
 import {generateCSSRuleset, generateCSS} from '../src/generate';
+import {setConfig} from '../src/util';
 
 describe('generateCSSRuleset', () => {
+    beforeEach(() => setConfig('useImportant', true));
     const assertCSSRuleset = (selector, declarations, expected) => {
         const actual = generateCSSRuleset(selector, declarations);
         assert.equal(actual, expected.split('\n').map(x => x.trim()).join(''));

--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -8,6 +8,7 @@ import {
     reset, startBuffering, flushToString, flushToStyleTag,
     addRenderedClassNames, getRenderedClassNames
 } from '../src/inject.js';
+import {setConfig} from '../src/util';
 
 const sheet = StyleSheet.create({
     red: {
@@ -25,6 +26,7 @@ const sheet = StyleSheet.create({
 
 describe('injection', () => {
     beforeEach(() => {
+        setConfig('useImportant', true);
         global.document = jsdom.jsdom();
         reset();
     });

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 
-import {recursiveMerge} from '../src/util.js';
+import {recursiveMerge, setConfig, getConfig, shouldUseImportant} from '../src/util.js';
 
 describe('Utils', () => {
     describe('recursiveMerge', () => {
@@ -25,6 +25,28 @@ describe('Utils', () => {
                     a: 1,
                     b: 2,
                 });
+        });
+    });
+    describe('setConfig', () => {
+        it('sets and gets options', () => {
+            setConfig('useImportant', false);
+            assert.strictEqual(getConfig('useImportant'), false);
+            setConfig('useImportant', true);
+            assert.strictEqual(getConfig('useImportant'), true);
+        });
+    });
+    describe('shouldUseImportant', () => {
+        it('applies !important when config.useImportant is true', () => {
+            setConfig('useImportant', true);
+            assert.strictEqual(shouldUseImportant(), true);
+        });
+        it('does not apply !important when config.useImportant is false', () => {
+            setConfig('useImportant', false);
+            assert.strictEqual(shouldUseImportant(), false);
+        });
+        it('allows the useImportant argument to override config', () => {
+            setConfig('useImportant', true);
+            assert.strictEqual(shouldUseImportant(false), false);
         });
     });
 });


### PR DESCRIPTION
This is an alternative implementation to #41 based on our discussion there. Closes #25

Given the concepts that:

* The use-case for adding `!important` to all generated styles is having a project with a legacy stylesheet that could clash with Aphrodite's classes
* Aphrodite can be used by components / libraries that should have no knowledge or opinion of whether `!important` is applied to the style definitions
* We want a consistent API for opting in or out of `!important` for all styles generated by Aphrodite in a project (and that this shouldn't be left to component authors to expose)

I've implemented config that can be set on the `aphrodite` package itself, and a single option that controls whether to use important or not.

So now to turn on `!important`, you would do the following _once_ in your project (probably alongside the app entry point):

```js
import { css, setConfig, StyleSheet } from 'aphrodite';
setConfig('useImportant', true);
```

This way, the setting will be applied consistently throughout the project regardless of the components being used, which I think is the best way to have this work.

The only downside I can see is that if someone uses a component styled by Aphrodite (without using Aphrodite in their project directly), and they needed to turn the `useImportant` setting on, they'd need to depend on aphrodite and include this somewhere in their project:

```js
require('aphrodite').setConfig('useImportant', true);
```

Given that the alternative is for components to individually expose an API for this, I think it's a reasonable trade-off. (come to think of it, you could expose that as an API on a component package anyway, although I'm not sure it's a good idea...)

I've updated the existing unit tests, and added tests for the new functionality. I'm happy to update the Readme with documentation as well, but wanted to submit this for review first.

Overall I've tested this in my own projects and am really happy with how it works, two thoughts on the new config concept:

* It seems like a little bit of overkill to add a config API when there's only one option, but it seemed cleaner than exposing something like `aphrodite.useImportant(true)` which wouldn't scale well if more options are added in the future.
* You could easily support syntax like `aphrodite.setConfig({ useImportant: true })` but the way I'd do that requires the `Object.assign` polyfill in babel which isn't configured, so I left that out for simplicity.

Finally, this implementation could behave unpredictably if more than one version of Aphrodite is included in a project... Given that's an edge case that React also has issues with, I think it's a reasonable trade-off.

Hope you like it!