### PR TITLE
Fix recursive merge when `a` has a null property

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -26,7 +26,8 @@ export const recursiveMerge = (a, b) => {
     // TODO(jlfwong): Handle malformed input where a and b are not the same
     // type.
 
-    if (typeof a !== 'object') {
+    // JSWat strikes again: typeof null === 'object'
+    if (a === null || typeof a !== 'object') {
         return b;
     }
 

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -123,6 +123,28 @@ describe('css', () => {
             done();
         });
     });
+
+    it('handles merging styles', done => {
+        const sheet1 = StyleSheet.create({
+            red: {
+                color: null,
+            },
+        });
+        const sheet2 = StyleSheet.create({
+            red: {
+                color: 'red',
+            },
+        });
+
+        css(sheet1.red, sheet2.red);
+
+        asap(() => {
+            const styleTags = global.document.getElementsByTagName("style");
+            const lastTag = styleTags[styleTags.length - 1];
+            assert.match(lastTag.textContent, /color:red !important/);
+            done();
+        });
+    })
 });
 
 describe('StyleSheet.create', () => {

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -26,5 +26,16 @@ describe('Utils', () => {
                     b: 2,
                 });
         });
+        it('handles null', () => {
+            assert.deepEqual(
+                recursiveMerge({
+                    a: null,
+                }, {
+                    a: 2,
+                }),
+                {
+                    a: 2,
+                });
+        });
     });
 });


### PR DESCRIPTION
This fixes the case where

``` js
css(
    StyleSheet.create({b: { color: null}}).b,
    StyleSheet.create({b: { color: 'blue'}}).b
)
```

results in `{color: {}}`

The reason was that `typeof null === 'object'`
Nothing like some good ol' Wat to make our lives interesting

Test Plan:
I added a test for this case in both recursive merge and css(x,y)
`npm test` shows all tests passing
