### PR TITLE
Sort properties to ensure prefixed properties precede unprefixed ones

### DIFF
--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -13,13 +13,13 @@ describe('generateCSSRuleset', () => {
         }, '.foo{color:red !important;}');
     });
 
-    it('returns a CSS string for multiple property', () => {
+    it('returns a CSS string for multiple properties', () => {
         assertCSSRuleset('.foo', {
             color: 'red',
             background: 'blue'
         }, `.foo{
-            color:red !important;
             background:blue !important;
+            color:red !important;
         }`);
     });
 
@@ -32,9 +32,10 @@ describe('generateCSSRuleset', () => {
     it('prefixes vendor props with a dash', () => {
         assertCSSRuleset('.foo', {
             transition: 'none'
-        }, '.foo{transition:none !important;'+
-           '-webkit-transition:none !important;' +
-           '}');
+        }, `.foo{
+           -webkit-transition:none !important;
+           transition:none !important;
+        }`);
     });
 
     it('converts ms prefix to -ms-', () => {
@@ -150,12 +151,21 @@ describe('generateCSS', () => {
     it('adds browser prefixes', () => {
         assertCSS('.foo', [{
             display: 'flex',
-        }], '.foo{display:-moz-box !important;display:-ms-flexbox !important;display:-webkit-box !important;display:-webkit-flex !important;display:flex !important;}');
+        }], `.foo{
+            display:-webkit-box !important;
+            display:-moz-box !important;
+            display:-ms-flexbox !important;
+            display:-webkit-flex !important;
+            display:flex !important;
+        }`);
     });
 
     it('correctly prefixes border-color transition properties', () => {
       assertCSS('.foo', [{
-        'transition': 'border-color 200ms linear'
-      }], '.foo{transition:border-color 200ms linear !important;-webkit-transition:border-color 200ms linear !important;}');
+        transition: 'border-color 200ms linear'
+      }], `.foo{
+        -webkit-transition:border-color 200ms linear !important;
+        transition:border-color 200ms linear !important;
+      }`);
     });
 });


### PR DESCRIPTION
I also changed the code to no longer sort the values when inline-style-prefixer
generates multiple values. It's not clear to me why exactly we were doing this,
but inline-style-prefixer seems to do the right thing. See #71 for original
context.

Fixes #100
