### PR TITLE
Improve syntax highlighting in readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --save aphrodite
 
 If you'd rather watch introductory videos, you can find them [here](https://www.youtube.com/playlist?list=PLo4Zh55ZzNSBP78pCD0dZJi9zf8CA72_M).
 
-```jsx
+```js
 import React, { Component } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 


### PR DESCRIPTION
## Before (Using `jsx` syntax highlighting):
<img width="672" alt="screen shot 2016-09-10 at 12 49 37" src="https://cloud.githubusercontent.com/assets/2257156/18413166/1618d894-7755-11e6-898f-d6534216eac2.png">
## After (Using `js` syntax highlighting):
<img width="662" alt="screen shot 2016-09-10 at 12 49 25" src="https://cloud.githubusercontent.com/assets/2257156/18413167/161c0320-7755-11e6-87da-8c25b2faafb5.png">
