### PR TITLE
Add a RunKit example to Aphrodite

### DIFF
--- a/examples/runkit.js
+++ b/examples/runkit.js
@@ -1,0 +1,33 @@
+// Aphrodite server-side rendering example
+
+// Make a component that generates some styles and returns some HTML.
+function render() {
+    const {StyleSheet, css} = require("aphrodite/no-important");
+
+    // Make some styles
+    const styles = StyleSheet.create({
+        red: {
+            color: "red",
+
+            ":hover": {
+                color: "blue",
+            },
+        },
+    });
+
+    // Generate some CSS with Aphrodite class names in it.
+    return `<div class=${css(styles.red)}>
+        Hover, and I'll turn blue!
+    </div>`;
+}
+
+const {StyleSheetServer} = require("aphrodite");
+
+// Call our render function inside of StyleSheetServer.renderStatic
+const {css, html} = StyleSheetServer.renderStatic(() => {
+    return render();
+});
+
+// Observe our output HTML and the Aphrodite-generated CSS
+console.log("Output HTML:", html);
+console.log("Output CSS:", css.content);

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   "dependencies": {
     "asap": "^2.0.3",
     "inline-style-prefixer": "^2.0.0"
-  }
+  },
+  "tonicExampleFilename": "examples/runkit.js"
 }


### PR DESCRIPTION
Summary: RunKit (previously TonicDev) lets you add a custom example on
the package page linked to from npmjs.com:
https://discuss.runkit.com/t/customizing-your-npm-packages-page-on-tonic/23

This adds such an example!

Closes #140

Test Plan:
 - Publish this as the new package, `aphrodite-test`
 - See that the runkit integration works :)