### PR TITLE
discussion: add cssGlobal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import {mapObj, hashObject} from './util';
 import {
-    injectAndGetClassName,
+    injectAndGetClassName, injectStyleOnce,
     reset, startBuffering, flushToString,
     addRenderedClassNames, getRenderedClassNames
 } from './inject';
@@ -77,9 +77,22 @@ const css = (...styleDefinitions) => {
     return injectAndGetClassName(useImportant, styleDefinitions);
 };
 
+const injectedGlobals = new WeakSet();
+const cssGlobal = (globalStyles) => {
+    if (injectedGlobals.has(globalStyles)) return;
+    injectedGlobals.add(globalStyles);
+    const selectors = Object.keys(globalStyles);
+    for (let i = 0; i < selectors.length; i++) {
+        const name = selectors[i];
+        const value = globalStyles[name];
+        injectStyleOnce(name, name, [value], false);
+    }
+};
+
 export default {
     StyleSheet,
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
+    cssGlobal
 };


### PR DESCRIPTION
Aphrodite is a lightweight package for modular styles. That's why we love it.
But some things aren't modular:
- fonts
- global resets/normalizers
- 3rd party css overrides

The current best practice is to use something other than aphrodite for these cases (except in the case of fonts, where aphrodite has kinda hacky logic).

With a _very_ small amount of code, we can support globals (including SSR).

Globals are actually very easy:
- They only need to be called once (no dependency on context/state/props)
- Aphrodite doesn't need to worry about cascade order because globals should be written as specific as necessary
- It allows aphrodite to get rid of that messy font handling (will adjust this PR if you like where this is going)

Why a 3rd party package doesn't work:
- `isBuffering` is private, which means the user must pass `injectStyleOnce` to their function (otherwise you'd have 2 discrete flush cycles for the SSR). This is doable: see [hepha](https://github.com/mattkrick/hepha). However, it'd be so much cleaner to include it in aphrodite as I'm sure everyone has a custom font, or `{margin: 0}` body tag  that they'd like to load properly :smile: