### PR TITLE
Support multiple animation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ import { StyleSheet, css } from 'aphrodite/no-important';
 
 ## Font Faces
 
-Creating custom font faces is a special case. Typically you need to define a global `@font-face` rule. In the case of aphrodite we only want to insert that rule if it's actually being referenced by a class that's in the page. We've made it so that the `fontFamily` property can accept a font-face object (either directly or inside an array). A global `@font-face` rule is then generated based on the font definition.
+Creating custom font faces is a special case. Typically you need to define a global `@font-face` rule. In the case of Aphrodite we only want to insert that rule if it's actually being referenced by a class that's in the page. We've made it so that the `fontFamily` property can accept a font-face object (either directly or inside an array). A global `@font-face` rule is then generated based on the font definition.
 
 ```js
 const coolFont = {
@@ -202,6 +202,48 @@ const styles = StyleSheet.create({
 ```
 
 Aphrodite will ensure that the global `@font-face` rule for this font is only inserted once, no matter how many times it's referenced.
+
+## Animations
+
+Similar to [Font Faces](#font-faces), Aphrodite supports keyframe animations, but it's treated as a special case. Once we find an instance of the animation being referenced, a global `@keyframes` rule is created and appended to the page.
+
+Animations are provided as objects describing the animation, in typical `@keyframes` fashion. Using the `animationName` property, you can supply a single animation object, or an array of animation objects. Other animation properties like `animationDuration` can be provided as strings.
+
+```js
+const translateKeyframes = {
+    '0%': {
+        transform: 'translateX(0)',
+    },
+
+    '50%': {
+        transform: 'translateX(100px)',
+    },
+
+    '100%': {
+        transform: 'translateX(0)',
+    },
+};
+
+const opacityKeyframes = {
+    'from': {
+        opacity: 0,
+    },
+
+    'to': {
+        opacity: 1,
+    }
+};
+
+const styles = StyleSheet.create({
+    zippyHeader: {
+        animationName: [translateKeyframes, opacityKeyframes],
+        animationDuration: '3s, 1200ms',
+        animationIterationCount: 'infinite',
+    },
+});
+```
+
+Aphrodite will ensure that `@keyframes` rules are never duplicated, no matter how many times a given rule is referenced.
 
 # Use without React
 

--- a/examples/src/StyleTester.js
+++ b/examples/src/StyleTester.js
@@ -36,7 +36,8 @@ const StyleTester = React.createClass({
             <span className={css(this.state.timer ? styles.red : styles.blue)}>This should alternate between red and blue every second.</span>,
             <a href='javascript: void 0' className={css(styles.pseudoSelectors)}>This should turn red on hover and ???? (blue or red) on active</a>,
             <div className={css(styles.flexCenter)}><div className={css(styles.flexInner)}>This should be centered inside the outer box, even in IE 10.</div></div>,
-            <span className={css(styles.animate)}>This should animate</span>,
+            <span className={css(styles.singleAnimation)}>This should animate from side to side</span>,
+            <span className={css(styles.doubleAnimation)}>This should animate from side to side, as well as fade in</span>,
         ];
 
         return <div>
@@ -46,14 +47,28 @@ const StyleTester = React.createClass({
 });
 
 
-const keyframes = {
+const translateKeyframes = {
+    '0%': {
+        transform: 'translateX(0)',
+    },
+
+    '50%': {
+        transform: 'translateX(100px)',
+    },
+
+    '100%': {
+        transform: 'translateX(0)',
+    },
+};
+
+const opacityKeyframes = {
     'from': {
-        marginLeft: 0,
+        opacity: 0,
     },
 
     'to': {
-        marginLeft: 100,
-    },
+        opacity: 1,
+    }
 };
 
 const styles = StyleSheet.create({
@@ -138,9 +153,17 @@ const styles = StyleSheet.create({
         textAlignLast: "justify",
     },
 
-    animate: {
-        animationName: keyframes,
-        animationDuration: '2s',
+    singleAnimation: {
+        display: 'inline-block',
+        animationName: translateKeyframes,
+        animationDuration: '3s',
+        animationIterationCount: 'infinite',
+    },
+
+    doubleAnimation: {
+        display: 'inline-block',
+        animationName: [translateKeyframes, opacityKeyframes],
+        animationDuration: '3s, 1200ms',
         animationIterationCount: 'infinite',
     },
 });

--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -409,5 +409,63 @@ describe('String handlers', () => {
             assert.include(styles, '@keyframes keyframe_1ptfkz1');
             assert.equal(styles.match(/@keyframes/g).length, 1);
         });
+
+        it('concatenates arrays of custom keyframes', () => {
+            const keyframes1 = {
+                'from': {
+                    left: 10,
+                },
+                'to': {
+                    left: 50,
+                },
+            };
+
+            const keyframes2 = {
+                'from': {
+                    top: -50,
+                },
+                'to': {
+                    top: 0,
+                },
+            };
+
+            const sheet = StyleSheet.create({
+                animate: {
+                    animationName: [keyframes1, keyframes2],
+                },
+            });
+
+            startBuffering();
+            css(sheet.animate);
+            flushToStyleTag();
+
+            assertStylesInclude('@keyframes keyframe_1q5qq7q');
+            assertStylesInclude('@keyframes keyframe_1sbxkmr');
+            assertStylesInclude('animation-name:keyframe_1q5qq7q,keyframe_1sbxkmr')
+        });
+
+        it('concatenates a custom keyframe animation with a plain string', () => {
+            const keyframes1 = {
+                'from': {
+                    left: 10,
+                },
+                'to': {
+                    left: 50,
+                },
+            };
+
+            const sheet = StyleSheet.create({
+                animate: {
+                    animationName: [keyframes1, 'hoo'],
+                },
+            });
+
+            startBuffering();
+            css(sheet.animate);
+            flushToStyleTag();
+
+            assertStylesInclude('@keyframes keyframe_1q5qq7q');
+            assertStylesInclude('animation-name:keyframe_1q5qq7q,hoo')
+        });
     });
 });


### PR DESCRIPTION
* Updated the `animationName` handler to accept arrays of animation
  names
* Added an example showcasing two asynchronous animations
* Updated documentation to include info about single and multiple
  animations.
* closes https://github.com/Khan/aphrodite/issues/78