### PR TITLE
Fix to prevent arrays being mutated into objects

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -37,6 +37,10 @@ const MS_RE = /^ms-/;
 const kebabify = (string /* : string */) /* : string */ => string.replace(UPPERCASE_RE, '-$1').toLowerCase();
 export const kebabifyStyleName = (string /* : string */) /* : string */ => kebabify(string).replace(MS_RE, '-ms-');
 
+const isNotObject = (
+  x/* : ObjectMap | any */
+) /* : boolean */ => typeof x !== 'object' || Array.isArray(x) || x === null;
+
 export const recursiveMerge = (
     a /* : ObjectMap | any */,
     b /* : ObjectMap */
@@ -44,7 +48,7 @@ export const recursiveMerge = (
     // TODO(jlfwong): Handle malformed input where a and b are not the same
     // type.
 
-    if (typeof a !== 'object' || Array.isArray(b)) {
+    if (isNotObject(a) || isNotObject(b)) {
         return b;
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -44,7 +44,7 @@ export const recursiveMerge = (
     // TODO(jlfwong): Handle malformed input where a and b are not the same
     // type.
 
-    if (typeof a !== 'object') {
+    if (typeof a !== 'object' || Array.isArray(b)) {
         return b;
     }
 

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -45,5 +45,25 @@ describe('Utils', () => {
                     a: [2],
                 });
         });
+        it('prefers the value from the override object if either property is not a true object', () => {
+            assert.deepEqual(
+                recursiveMerge({
+                    a: { b: 2 },
+                }, {
+                    a: null,
+                }),
+                {
+                    a: null,
+                });
+            assert.deepEqual(
+                recursiveMerge({
+                    a: null,
+                }, {
+                    a: { b: 2 },
+                }),
+                {
+                    a: { b: 2 },
+                });
+        });
     });
 });

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -34,7 +34,7 @@ describe('Utils', () => {
                     b: 2,
                 });
         });
-        it('does not mutate Arrays into Objects', () => {
+        it('replaces arrays rather than merging them', () => {
             assert.deepEqual(
                 recursiveMerge({
                     a: [1],

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -34,5 +34,16 @@ describe('Utils', () => {
                     b: 2,
                 });
         });
+        it('does not mutate Arrays into Objects', () => {
+            assert.deepEqual(
+                recursiveMerge({
+                    a: [1],
+                }, {
+                    a: [2],
+                }),
+                {
+                    a: [2],
+                });
+        });
     });
 });


### PR DESCRIPTION
When recursively merging it will currently convert an array into an object which, when merging two styles with `fontFamily` properties, cause the generated style to set it as `"undefined"`.

e.g. `font-family: "undefined"`