### PR TITLE
Allow specifying styles as `Map`s to guarantee ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,82 @@ then we end up with the opposite effect, with `foo` overriding `bar`! The way to
 }
 ```
 
+## Object key ordering
+
+When styles are specified in Aphrodite, the order that they appear in the
+actual stylesheet depends on the order that keys are retrieved from the
+objects. This ordering is determined by the JavaScript engine that is being
+used to render the styles. Sometimes, the order that the styles appear in the
+stylesheet matter for the semantics of the CSS. For instance, depending on the
+engine, the styles generated from
+
+```js
+const styles = StyleSheet.create({
+    ordered: {
+        margin: 0,
+        marginLeft: 15,
+    },
+});
+css(styles.ordered);
+```
+
+you might expect the following CSS to be generated:
+
+```css
+margin: 0px;
+margin-left: 15px;
+```
+
+but depending on the ordering of the keys in the style object, the CSS might
+appear as
+
+```css
+margin-left: 15px;
+margin: 0px;
+```
+
+which is semantically different, because the style which appears later will
+override the style before it.
+
+This might also manifest as a problem when server-side rendering, if the
+generated styles appear in a different order on the client and on the server.
+
+If you experience this issue where styles don't appear in the generated CSS in
+the order that they appear in your objects, there are two solutions:
+
+1. Don't use shorthand properties. For instance, in the margin example above,
+   by switching from using a shorthand property and a longhand property in the
+   same styles to using only longhand properties, the issue could be avoided.
+
+   ```js
+   const styles = StyleSheet.create({
+       ordered: {
+           marginTop: 0,
+           marginRight: 0,
+           marginBottom: 0,
+           marginLeft: 15,
+       },
+   });
+   ```
+
+2. Specify the ordering of your styles by specifying them using a
+   [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
+   Since `Map`s preserve their insertion order, Aphrodite is able to place your
+   styles in the correct order.
+
+   ```js
+   const styles = StyleSheet.create({
+       ordered: new Map([
+           ["margin", 0],
+           ["marginLeft", 15],
+       ]),
+   });
+   ```
+
+   Note that `Map`s are not fully supported in all browsers. It can be
+   polyfilled by using a package
+   like [es6-shim](https://www.npmjs.com/package/es6-shim).
+
 ## Advanced: Extensions
 
 Extra features can be added to Aphrodite using extensions.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
     "chai": "^3.3.0",
+    "es6-shim": "^0.35.3",
     "eslint": "^3.7.1",
     "eslint-config-standard-react": "^4.2.0",
     "eslint-plugin-react": "^6.3.0",

--- a/src/ordered-elements.js
+++ b/src/ordered-elements.js
@@ -1,0 +1,84 @@
+/* @flow */
+/* global Map */
+
+export default class OrderedElements {
+    /* ::
+    elements: {[string]: any};
+    keyOrder: string[];
+
+    static fromObject: ({[string]: any}) => OrderedElements;
+    static fromMap: (Map<string,any>) => OrderedElements;
+    static from: (Map<string,any> | {[string]: any} | OrderedElements) =>
+        OrderedElements;
+    */
+
+    constructor(
+        elements /* : {[string]: any} */ = {},
+        keyOrder /* : string[] */ = []
+    ) {
+        this.elements = elements;
+        this.keyOrder = keyOrder;
+    }
+
+    forEach(callback /* : (string, any) => void */) {
+        for (let i = 0; i < this.keyOrder.length; i++) {
+            callback(this.keyOrder[i], this.elements[this.keyOrder[i]]);
+        }
+    }
+
+    map(callback /* : (string, any) => any */) /* : OrderedElements */ {
+        const results = new OrderedElements();
+        for (let i = 0; i < this.keyOrder.length; i++) {
+            results.set(
+                this.keyOrder[i],
+                callback(this.keyOrder[i], this.elements[this.keyOrder[i]])
+            );
+        }
+        return results;
+    }
+
+    set(key /* : string */, value /* : any */) {
+        if (!this.elements.hasOwnProperty(key)) {
+            this.keyOrder.push(key);
+        }
+        this.elements[key] = value;
+    }
+
+    get(key /* : string */) /* : any */ {
+        return this.elements[key];
+    }
+
+    has(key /* : string */) /* : boolean */ {
+        return this.elements.hasOwnProperty(key);
+    }
+}
+
+OrderedElements.fromObject = (obj) => {
+    return new OrderedElements(obj, Object.keys(obj));
+};
+
+OrderedElements.fromMap = (map) => {
+    const ret = new OrderedElements();
+    map.forEach((val, key) => {
+        ret.set(key, val);
+    });
+    return ret;
+};
+
+OrderedElements.from = (obj) => {
+    if (obj instanceof OrderedElements) {
+        // NOTE(emily): This makes a shallow copy of the previous elements, so
+        // if the elements are deeply modified it will affect all copies.
+        return new OrderedElements({...obj.elements}, obj.keyOrder.slice());
+    } else if (
+        // For some reason, flow complains about a plain
+        // `typeof Map !== "undefined"` check. Casting `Map` to `any` solves
+        // the problem.
+        typeof /*::(*/ Map /*: any)*/ !== "undefined" &&
+        obj instanceof Map
+    ) {
+        return OrderedElements.fromMap(obj);
+    } else {
+        return OrderedElements.fromObject(obj);
+    }
+};

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -1,12 +1,15 @@
 import {assert} from 'chai';
 
+import OrderedElements from '../src/ordered-elements';
 import {
     generateCSSRuleset, generateCSS, defaultSelectorHandlers
 } from '../src/generate';
 
 describe('generateCSSRuleset', () => {
     const assertCSSRuleset = (selector, declarations, expected) => {
-        const actual = generateCSSRuleset(selector, declarations);
+        const actual = generateCSSRuleset(
+            selector,
+            OrderedElements.from(declarations));
         assert.equal(actual, expected.split('\n').map(x => x.trim()).join(''));
     };
     it('returns a CSS string for a single property', () => {
@@ -153,8 +156,28 @@ describe('generateCSS', () => {
     it('adds browser prefixes', () => {
         assertCSS('.foo', [{
             display: 'flex',
-        }], '.foo{display:-moz-box !important;display:-ms-flexbox !important;display:-webkit-box !important;display:-webkit-flex !important;display:flex !important;}',
-            defaultSelectorHandlers);
+            transition: 'all 0s',
+            alignItems: 'center',
+            WebkitAlignItems: 'center',
+            justifyContent: 'center',
+        }], '.foo{' +
+            '-ms-flex-pack:center !important;' +
+            '-webkit-box-align:center !important;' +
+            '-ms-flex-align:center !important;' +
+            '-webkit-box-pack:center !important;' +
+            'display:flex !important;' +
+            'display:-webkit-flex !important;' +
+            'display:-ms-flexbox !important;' +
+            'display:-moz-box !important;' +
+            'display:-webkit-box !important;' +
+            '-webkit-transition:all 0s !important;' +
+            'transition:all 0s !important;' +
+            'align-items:center !important;' +
+            '-webkit-align-items:center !important;' +
+            '-webkit-justify-content:center !important;' +
+            'justify-content:center !important;' +
+        '}',
+        defaultSelectorHandlers);
     });
 
     it('supports other selector handlers', () => {

--- a/tests/ordered-elements_test.js
+++ b/tests/ordered-elements_test.js
@@ -1,0 +1,120 @@
+/* global Map */
+import {assert} from 'chai';
+
+import OrderedElements from '../src/ordered-elements';
+
+import "es6-shim";
+
+describe("OrderedElements", () => {
+    it("generates from an object", () => {
+        const orig = {
+            a: 1,
+            b: 2,
+        };
+
+        const elems = OrderedElements.from(orig);
+
+        assert.deepEqual({
+            elements: orig,
+            keyOrder: ["a", "b"],
+        }, elems);
+    });
+
+    it("generates from a Map", () => {
+        const orig = new Map([
+            ["a", 1],
+            ["b", 2]
+        ]);
+
+        const elems = OrderedElements.from(orig);
+
+        assert.deepEqual({
+            elements: {
+                a: 1,
+                b: 2,
+            },
+            keyOrder: ["a", "b"],
+        }, elems);
+    });
+
+    it("generates from a OrderedElements", () => {
+        const orig = new OrderedElements();
+
+        orig.set("a", 1);
+        orig.set("b", 2);
+
+        const elems = OrderedElements.from(orig);
+
+        assert.deepEqual(orig, elems);
+    });
+
+    it("adds new elements in order", () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("b", 2);
+
+        assert.deepEqual({
+            elements: {
+                a: 1,
+                b: 2,
+            },
+            keyOrder: ["a", "b"],
+        }, elems);
+    });
+
+    it("overrides old elements but doesn't add to the key ordering", () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("a", 2);
+
+        assert.deepEqual({
+            elements: {
+                a: 2,
+            },
+            keyOrder: ["a"],
+        }, elems);
+    });
+
+    it("iterates over the elements in the correct order", () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("b", 2);
+        elems.set("c", 3);
+
+        const order = [];
+
+        elems.forEach((key, value) => {
+            order.push([key, value]);
+        });
+
+        assert.deepEqual([
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
+        ], order);
+    });
+
+    it("maps over the elements, making a new OrderedElements from the result", () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("b", 2);
+        elems.set("c", 3);
+
+        const mapped = elems.map((key, value) => {
+            return value + 1;
+        });
+
+        assert.deepEqual({
+            elements: {
+                a: 2,
+                b: 3,
+                c: 4,
+            },
+            keyOrder: ["a", "b", "c"],
+        }, mapped);
+    });
+});

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,6 +1,9 @@
+/* global Map */
 import {assert} from 'chai';
 
 import {flattenDeep, kebabifyStyleName, recursiveMerge} from '../src/util.js';
+
+import "es6-shim";
 
 describe('Utils', () => {
     describe('flattenDeep', () => {
@@ -20,7 +23,10 @@ describe('Utils', () => {
                     a: 2,
                 }),
                 {
-                    a: 2,
+                    elements: {
+                        a: 2,
+                    },
+                    keyOrder: ["a"],
                 });
 
             assert.deepEqual(
@@ -30,8 +36,58 @@ describe('Utils', () => {
                     b: 2,
                 }),
                 {
-                    a: 1,
-                    b: 2,
+                    elements: {
+                        a: 1,
+                        b: 2,
+                    },
+                    keyOrder: ["a", "b"],
+                });
+        });
+
+        it('merges maps together', () => {
+            assert.deepEqual(
+                recursiveMerge(
+                    new Map([['a', 1], ['b', 2]]),
+                    new Map([['a', 3], ['c', 4]])
+                ),
+                {
+                    elements: {
+                        a: 3,
+                        b: 2,
+                        c: 4,
+                    },
+                    keyOrder: ["a", "b", "c"],
+                });
+        });
+
+        it('merges maps and objects together', () => {
+            assert.deepEqual(
+                [
+                    new Map([['a', 1]]),
+                    {a: 2, b: 3},
+                    new Map([['b', 4], ['c', 5]]),
+                ].reduce(recursiveMerge),
+                {
+                    elements: {
+                        a: 2,
+                        b: 4,
+                        c: 5,
+                    },
+                    keyOrder: ["a", "b", "c"],
+                });
+        });
+
+        it('generates OrderedElements from merging an object into a non-object', () => {
+            assert.deepEqual(
+                recursiveMerge(
+                    1,
+                    {a: 1},
+                ),
+                {
+                    elements: {
+                        a: 1,
+                    },
+                    keyOrder: ["a"],
                 });
         });
         it('replaces arrays rather than merging them', () => {
@@ -42,9 +98,13 @@ describe('Utils', () => {
                     a: [2],
                 }),
                 {
-                    a: [2],
+                    elements: {
+                        a: [2],
+                    },
+                    keyOrder: ["a"],
                 });
         });
+
         it('prefers the value from the override object if either property is not a true object', () => {
             assert.deepEqual(
                 recursiveMerge({
@@ -53,8 +113,12 @@ describe('Utils', () => {
                     a: null,
                 }),
                 {
-                    a: null,
+                    elements: {
+                        a: null,
+                    },
+                    keyOrder: ["a"],
                 });
+
             assert.deepEqual(
                 recursiveMerge({
                     a: null,
@@ -62,7 +126,15 @@ describe('Utils', () => {
                     a: { b: 2 },
                 }),
                 {
-                    a: { b: 2 },
+                    elements: {
+                        a: {
+                            elements: {
+                                b: 2,
+                            },
+                            keyOrder: ["b"],
+                        },
+                    },
+                    keyOrder: ["a"],
                 });
         });
     });


### PR DESCRIPTION
Summary: Key ordering in objects can be different in different environments.
Sometimes, this causes problems, like where styles generated on the server are
not in the same order as the same styles generated on the client. This
manifests in problems such as #199

This change lets users manually fix instances where the ordering of elements
changes by specifying their styles in an ES6 `Map`, which has defined value
ordering.

In order to accomplish this, an `OrderedElements` class was created, which is
sorta like a `Map` but can only store string keys and lacks most of the
features. Internally, `Map`s and objects are converted into this and then these
are merged together to preserve the ordering.

Fixes #199

Test Plan:
 - `npm test`

@lencioni @ljharb