### PR TITLE
Improve `importantify()` performance

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -284,12 +284,13 @@ export const generateCSSRuleset = (
         })
     );
 
-    const rules = prefixedRules.map(([key, value]) => {
-        const stringValue = (useImportant === false)
-            ? stringifyValue(key, value)
-            : importantify(stringifyValue(key, value));
-        return `${kebabifyStyleName(key)}:${stringValue};`;
-    }).join("");
+    const transformValue = (useImportant === false)
+        ? stringifyValue
+        : (key, value) => importantify(stringifyValue(key, value));
+
+    const rules = prefixedRules
+        .map(([key, value]) => `${kebabifyStyleName(key)}:${transformValue(key, value)};`)
+        .join("");
 
     if (rules) {
         return `${selector}{${rules}}`;

--- a/src/generate.js
+++ b/src/generate.js
@@ -285,9 +285,10 @@ export const generateCSSRuleset = (
     );
 
     const rules = prefixedRules.map(([key, value]) => {
-        const stringValue = stringifyValue(key, value);
-        const ret = `${kebabifyStyleName(key)}:${stringValue};`;
-        return useImportant === false ? ret : importantify(ret);
+        const stringValue = (useImportant === false)
+            ? stringifyValue(key, value)
+            : importantify(stringifyValue(key, value));
+        return `${kebabifyStyleName(key)}:${stringValue};`;
     }).join("");
 
     if (rules) {

--- a/src/util.js
+++ b/src/util.js
@@ -215,9 +215,10 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object /* : ObjectMap */) /* : string */ => murmurhash2_32_gc(JSON.stringify(object));
 
 
-const IMPORTANT_RE = /(?: !important)?$/;
-
 // Given a single style value string like the "b" from "a: b;", adds !important
 // to generate "b !important".
-export const importantify = (string /* : string */) /* : string */ =>
-    string.replace(IMPORTANT_RE, " !important");
+export const importantify = (string /* : string */) /* : string */ => (
+    string.slice(-11) === ' !important'
+        ? string
+        : `${string} !important`
+);

--- a/src/util.js
+++ b/src/util.js
@@ -215,9 +215,9 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object /* : ObjectMap */) /* : string */ => murmurhash2_32_gc(JSON.stringify(object));
 
 
-const IMPORTANT_RE = /(?: !important)?;$/;
+const IMPORTANT_RE = /(?: !important)?$/;
 
-// Given a single style rule string like "a: b;", adds !important to generate
-// "a: b !important;".
+// Given a single style value string like the "b" from "a: b;", adds !important
+// to generate "b !important".
 export const importantify = (string /* : string */) /* : string */ =>
-    string.replace(IMPORTANT_RE, " !important;");
+    string.replace(IMPORTANT_RE, " !important");

--- a/src/util.js
+++ b/src/util.js
@@ -220,6 +220,4 @@ const IMPORTANT_RE = /^([^:]+:.*?)(?: !important)?;$/;
 // Given a single style rule string like "a: b;", adds !important to generate
 // "a: b !important;".
 export const importantify = (string /* : string */) /* : string */ =>
-    string.replace(
-        IMPORTANT_RE,
-        (_, base) => base + " !important;");
+    string.replace(IMPORTANT_RE, "$1 !important;");

--- a/src/util.js
+++ b/src/util.js
@@ -218,7 +218,12 @@ export const hashObject = (object /* : ObjectMap */) /* : string */ => murmurhas
 // Given a single style value string like the "b" from "a: b;", adds !important
 // to generate "b !important".
 export const importantify = (string /* : string */) /* : string */ => (
-    string.slice(-11) === ' !important'
+    // Bracket string character access is very fast, and in the default case we
+    // normally don't expect there to be "!important" at the end of the string
+    // so we can use this simple check to take an optimized path. If there
+    // happens to be a "!" in this position, we follow up with a more thorough
+    // check.
+    (string[string.length - 10] === '!' && string.slice(-11) === ' !important')
         ? string
         : `${string} !important`
 );

--- a/src/util.js
+++ b/src/util.js
@@ -215,9 +215,9 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object /* : ObjectMap */) /* : string */ => murmurhash2_32_gc(JSON.stringify(object));
 
 
-const IMPORTANT_RE = /^([^:]+:.*?)(?: !important)?;$/;
+const IMPORTANT_RE = /(?: !important)?;$/;
 
 // Given a single style rule string like "a: b;", adds !important to generate
 // "a: b !important;".
 export const importantify = (string /* : string */) /* : string */ =>
-    string.replace(IMPORTANT_RE, "$1 !important;");
+    string.replace(IMPORTANT_RE, " !important;");

--- a/src/util.js
+++ b/src/util.js
@@ -215,7 +215,7 @@ function murmurhash2_32_gc(str) {
 export const hashObject = (object /* : ObjectMap */) /* : string */ => murmurhash2_32_gc(JSON.stringify(object));
 
 
-const IMPORTANT_RE = /^([^:]+:.*?)( !important)?;$/;
+const IMPORTANT_RE = /^([^:]+:.*?)(?: !important)?;$/;
 
 // Given a single style rule string like "a: b;", adds !important to generate
 // "a: b !important;".


### PR DESCRIPTION
I was rolling through the code here looking for some opportunities to
speed it up and I noticed that there is a capture group in this regex
that isn't being used. By changing `(` to `(?:` we can avoid capturing
this group while still being able to use the parens for grouping.

I was also curious about the performance characteristics of various `replace`
arguments, and using a string in this way seems to have the edge, at least in
Firefox (35% faster) and Safari (12% faster)--Chrome performance seems
pretty similar for all possibilities. I also find this version more
readable, so it seems like we may as well go with this option.

https://jsperf.com/replace-string-vs-function/

I don't think we actually need a capture group at all here and can
accomplish the same thing by just anchoring on the end of the string.
This reduces the runtime of this function in my benchmark from ~105ms to
~35ms.