### PR TITLE
Avoid full string scan in generateCSSRuleset

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -264,7 +264,7 @@ export const generateCSSRuleset = (
                 const unprefixedValues = [];
 
                 value.forEach(v => {
-                  if (v.indexOf('-') === 0) {
+                  if (v[0] === '-') {
                     prefixedValues.push(v);
                   } else {
                     unprefixedValues.push(v);


### PR DESCRIPTION
Bracket access is a better choice here. This probably won't have a huge
impact, but I don't see any reason to not do it.

JSPerf shows this to be about 25% faster, and I assume the performance
difference is even better as the string gets longer:

  https://jsperf.com/test-start-of-string/1