### PR TITLE
Sort prefixed values before unprefixed values with the same key

### DIFF
--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -194,11 +194,11 @@ ${formatStyles(actual)}
             '-ms-flex-pack:center !important;' +
             '-webkit-box-align:center !important;' +
             '-ms-flex-align:center !important;' +
-            'display:flex !important;' +
             'display:-webkit-box !important;' +
             'display:-ms-flexbox !important;' +
             'display:-webkit-flex !important;' +
             'display:-moz-box !important;' +
+            'display:flex !important;' +
             '-webkit-transition:all 0s !important;' +
             '-moz-transition:all 0s !important;' +
             'transition:all 0s !important;' +


### PR DESCRIPTION
Summary: In #200 the way we started sorting prefixed and unprefixed values
differently. This builds on that by making sure that when style values are
prefixed, they come before the unprefixed values with the same key.

E.g.

```css
display: -webkit-flex; // prefixed value comes before
display: flex;         // unprefixed value
```

@lencioni