### PR TITLE
Handle null property values

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -159,7 +159,7 @@ export const stringifyValue = (
             return prop + "px";
         }
     } else {
-        return prop;
+        return '' + prop;
     }
 };
 

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -235,4 +235,15 @@ ${formatStyles(actual)}
           'transition:border-color 200ms linear !important;' +
       '}');
     });
+
+    // TODO(emily): In the future, filter out null values.
+    it('handles nullish values', () => {
+      assertCSS('.foo', [{
+          'color': null,
+          'margin': undefined,
+      }], '.foo{' +
+          'color:null !important;' +
+          'margin:undefined !important;' +
+      '}');
+    });
 });


### PR DESCRIPTION
Summary: The recent changes to `importantify` made it no longer worked when
passed in non-strings (such as `null` and `undefined`). This recovers the old
behaviour by manually converting the input to a string, and adds a test to make
sure this edge case is handled in the future.

Fixes #210

Test Plan:
 - `npm run test`

@lencioni