### PR TITLE
Optimize injectAndGetClassName

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -219,19 +219,29 @@ export const injectAndGetClassName = (
 ) /* : string */ => {
     styleDefinitions = flattenDeep(styleDefinitions);
 
-    // Filter out falsy values from the input, to allow for
-    // `css(a, test && c)`
-    const validDefinitions = styleDefinitions.filter((def) => def);
-
+    const classNameBits = [];
+    const definitionBits = [];
+    for (let i = 0; i < styleDefinitions.length; i += 1) {
+        // Filter out falsy values from the input, to allow for
+        // `css(a, test && c)`
+        if (styleDefinitions[i]) {
+            classNameBits.push(styleDefinitions[i]._name);
+            definitionBits.push(styleDefinitions[i]._definition);
+        }
+    }
     // Break if there aren't any valid styles.
-    if (validDefinitions.length === 0) {
+    if (classNameBits.length === 0) {
         return "";
     }
+    const className = classNameBits.join("-o_O-");
 
-    const className = validDefinitions.map(s => s._name).join("-o_O-");
-    injectStyleOnce(className, `.${className}`,
-        validDefinitions.map(d => d._definition),
-        useImportant, selectorHandlers);
+    injectStyleOnce(
+        className,
+        `.${className}`,
+        definitionBits,
+        useImportant,
+        selectorHandlers
+    );
 
     return className;
 }


### PR DESCRIPTION
This function is called every time css() is used, so we want it to be as
fast as possible. I spotted three loops here that could be condensed
into one. In my profiling this seems to make the function about 30%
faster.