### PR TITLE
Optimize flattenDeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
+    "array-flatten": "^2.1.1",
     "asap": "^2.0.3",
     "inline-style-prefixer": "^3.0.1",
     "string-hash": "^1.1.3"

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,8 +1,9 @@
 /* @flow */
 import asap from 'asap';
+import {from as flattenDeep} from 'array-flatten';
 
 import {generateCSS} from './generate';
-import {flattenDeep, hashObject} from './util';
+import {hashObject} from './util';
 
 /* ::
 import type { SheetDefinition, SheetDefinitions } from './index.js';

--- a/src/util.js
+++ b/src/util.js
@@ -30,9 +30,6 @@ export const mapObj = (
 // [[A], [B, C, [D]]] -> [A, B, C, [D]]
 export const flatten = (list /* : any[] */) /* : any[] */ => list.reduce((memo, x) => memo.concat(x), []);
 
-export const flattenDeep = (list /* : any[] */) /* : any[] */ =>
-    list.reduce((memo, x) => memo.concat(Array.isArray(x) ? flattenDeep(x) : x), []);
-
 const UPPERCASE_RE = /([A-Z])/g;
 const UPPERCASE_RE_TO_KEBAB = (match /* : string */)  /* : string */ => `-${match.toLowerCase()}`;
 

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,19 +1,11 @@
 /* global Map */
 import {assert} from 'chai';
 
-import {flattenDeep, kebabifyStyleName, recursiveMerge} from '../src/util.js';
+import {kebabifyStyleName, recursiveMerge} from '../src/util.js';
 
 import "es6-shim";
 
 describe('Utils', () => {
-    describe('flattenDeep', () => {
-        it('flattens arrays at any level', () => {
-            assert.deepEqual(
-                flattenDeep([[1, [2, 3, []]], 4, [[5], [6, [7]]]]),
-                [1, 2, 3, 4, 5, 6, 7]);
-        });
-    });
-
     describe('recursiveMerge', () => {
         it('merges two objects', () => {
             assert.deepEqual(


### PR DESCRIPTION
This is called by injectAndGetClassName which is called by css, so we
want it to be as fast as possible. The array-flatten package serves the
same purpose and has been well-optimized. Dropping that in here, makes
this go much faster, about 2-3 times faster in my profiling.

@xymostech 