### PR TITLE
Exclude tests directory from test coverage, update .gitignore and .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+*/node_modules
+coverage
 dist
 lib
-*/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.DS_Store
+.eslintcache
+.nyc_output
+coverage
+dist/*.map
 lib
 node_modules
-dist/*.map
-.nyc_output
-.eslintcache

--- a/package.json
+++ b/package.json
@@ -67,5 +67,12 @@
     "inline-style-prefixer": "^3.0.1",
     "string-hash": "^1.1.3"
   },
-  "tonicExampleFilename": "examples/runkit.js"
+  "tonicExampleFilename": "examples/runkit.js",
+  "nyc": {
+    "exclude": [
+      "**/node_modules/**",
+      "coverage",
+      "tests"
+    ]
+  }
 }

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -194,9 +194,9 @@ ${formatStyles(actual)}
             '-ms-flex-pack:center !important;' +
             '-webkit-box-align:center !important;' +
             '-ms-flex-align:center !important;' +
+            'display:-webkit-flex !important;' +
             'display:-webkit-box !important;' +
             'display:-ms-flexbox !important;' +
-            'display:-webkit-flex !important;' +
             'display:-moz-box !important;' +
             'display:flex !important;' +
             '-webkit-transition:all 0s !important;' +


### PR DESCRIPTION
I pulled these commits off of #216 to reduce the size of that PR.

We don't need to ensure that tests fully pass coverage. nyc by default
has some patterns to exclude tests, but they didn't match the naming
convention of this project, so I am updating it here.

https://github.com/istanbuljs/nyc#excluding-files