### PR TITLE
Fix bug where styles have their media queries removed on IE

### DIFF
--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -117,6 +117,24 @@ describe('injection', () => {
             });
         });
 
+        it('properly adds multiple styles to .styleSheet.cssText if available', done => {
+            const styleTag = global.document.createElement("style");
+            styleTag.setAttribute("data-aphrodite", "");
+            document.head.appendChild(styleTag);
+            styleTag.styleSheet = { cssText: "" };
+
+            injectStyleOnce("x", ".x", [{ color: "red" }], false);
+            injectStyleOnce("y", ".y", [{ color: "blue" }], false);
+
+            asap(() => {
+                assert.include(styleTag.styleSheet.cssText, ".x{");
+                assert.include(styleTag.styleSheet.cssText, "color:red");
+                assert.include(styleTag.styleSheet.cssText, ".y{");
+                assert.include(styleTag.styleSheet.cssText, "color:blue");
+                done();
+            });
+        });
+
         it('uses document.getElementsByTagName without document.head', done => {
             Object.defineProperty(global.document, "head", {
                 value: null,


### PR DESCRIPTION
In IE 9, appending two styles with media queries to a `StyleSheet`'s `cssText` property results in the first style's media query being removed and that first style will always apply without the query.

For example:

```js
var styleTag = document.createElement('style');
document.body.appendChild(styleTag);
styleTag.styleSheet.cssText +=
  '@media (min-width: 500px) { body { background-color: blue; } }';
styleTag.styleSheet.cssText +=
  '@media (min-width: 700px) { body { background-color: red; } }';
```

Causes the body element to be red for window widths ≥ 700px, but it is blue otherwise, even at widths < 500px.

This change adds a `styleString` variable that keeps track of the contents of the current `styleTag`, and updates the `cssText` content with `styleString` instead of appending to it with `+=`.

[Here's a JS Bin that demonstrates the issue](http://jsbin.com/nitezecovo/edit), which includes a commented-out solution. Note that the JS Bin won't work outside of IE. If you don't want to open up IE you can take a look at these gifs, recorded on IE 9:

### Using `styleSheet.cssText`
![broken example](https://cloud.githubusercontent.com/assets/7074605/25763796/a9978a26-3199-11e7-8c0a-85cb3688ce53.gif)

### Using `innerText`
![working example](https://cloud.githubusercontent.com/assets/7074605/25763844/dfd36bf0-3199-11e7-9fb3-2ffd2ab49949.gif)

