### PR TITLE
Use `insertRule` to inject styles

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -57,10 +57,7 @@ const injectStyleTag = (cssRules /* : string[] */) => {
             }
         });
     } else {
-        const currentStyleTag = styleTag;
-        cssRules.forEach((rule) => {
-            currentStyleTag.innerText = (currentStyleTag.innerText || '') + rule;
-        });
+        styleTag.innerText = (styleTag.innerText || '') + cssRules.join('');
     }
 };
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -47,9 +47,11 @@ const injectStyleTag = (cssContents /* : string[] */) => {
     const sheet = ((styleTag.styleSheet || styleTag.sheet /* : any */) /* : CSSStyleSheet */);
 
     if (sheet.insertRule) {
+        let numRules = sheet.cssRules.length;
         cssContents.forEach((rule) => {
             try {
-                sheet.insertRule(rule, sheet.cssRules.length);
+                sheet.insertRule(rule, numRules);
+                numRules += 1;
             } catch(e) {
                 // The selector for this rule wasn't compatible with the browser
             }

--- a/src/inject.js
+++ b/src/inject.js
@@ -21,12 +21,12 @@ type ProcessedStyleDefinitions = {
 // faster.
 let styleTag /* : ?HTMLStyleElement */ = null;
 
-// Inject a string of styles into a <style> tag in the head of the document. This
+// Inject a set of rules into a <style> tag in the head of the document. This
 // will automatically create a style tag and then continue to use it for
 // multiple injections. It will also use a style tag with the `data-aphrodite`
 // tag on it if that exists in the DOM. This could be used for e.g. reusing the
 // same style tag that server-side rendering inserts.
-const injectStyleTag = (cssContents /* : string[] */) => {
+const injectStyleTag = (cssRules /* : string[] */) => {
     if (styleTag == null) {
         // Try to find a style tag with the `data-aphrodite` attribute first.
         styleTag = ((document.querySelector("style[data-aphrodite]") /* : any */) /* : ?HTMLStyleElement */);
@@ -48,7 +48,7 @@ const injectStyleTag = (cssContents /* : string[] */) => {
 
     if (sheet.insertRule) {
         let numRules = sheet.cssRules.length;
-        cssContents.forEach((rule) => {
+        cssRules.forEach((rule) => {
             try {
                 sheet.insertRule(rule, numRules);
                 numRules += 1;
@@ -58,7 +58,7 @@ const injectStyleTag = (cssContents /* : string[] */) => {
         });
     } else {
         const currentStyleTag = styleTag;
-        cssContents.forEach((rule) => {
+        cssRules.forEach((rule) => {
             currentStyleTag.innerText = (currentStyleTag.innerText || '') + rule;
         });
     }
@@ -223,9 +223,9 @@ export const flushToString = () => {
 };
 
 export const flushToStyleTag = () => {
-    const cssContent = flushToArray();
-    if (cssContent.length > 0) {
-        injectStyleTag(cssContent);
+    const cssRules = flushToArray();
+    if (cssRules.length > 0) {
+        injectStyleTag(cssRules);
     }
 };
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -145,7 +145,7 @@ const stringHandlers = {
 let alreadyInjected = {};
 
 // This is the buffer of styles which have not yet been flushed.
-let injectionBuffer = [];
+let injectionBuffer /* : string[] */ = [];
 
 // A flag to tell if we are already buffering styles. This could happen either
 // because we scheduled a flush call already, so newly added styles will

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -349,6 +349,23 @@ ${formatStyles(actual)}
         }], ['.foo{color:blue;}','.bar .foo{color:red;}'], [handler], {}, false);
     });
 
+    it('supports selector handlers that return strings containing multiple rules', () => {
+        const handler = (selector, baseSelector, callback) => {
+            if (selector[0] !== '^') {
+                return null;
+            }
+            const generatedBefore = callback(baseSelector + '::before');
+            const generatedAfter = callback(baseSelector + '::after');
+            return `${generatedBefore} ${generatedAfter}`;
+        };
+
+        assertCSS('.foo', [{
+            '^': {
+                color: 'red',
+            },
+        }], ['@media all {.foo::before{color:red;} .foo::after{color:red;}}'], [handler], {}, false);
+    });
+
     it('correctly prefixes border-color transition properties', () => {
         assertCSS('.foo', [{
             'transition': 'border-color 200ms linear'

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -106,9 +106,10 @@ describe('generateCSS', () => {
                        stringHandlers = {}, useImportant = true) => {
         const actual = generateCSS(className, styleTypes, selectorHandlers,
                                    stringHandlers, useImportant);
-        const expectedNormalized = expected.split('\n').map(x => x.trim()).join('');
-        const formatStyles = (styles) => styles.replace(/(;|{|})/g, '$1\n');
-        assert.equal(
+        const expectedArray = [].concat(expected);
+        const expectedNormalized = expectedArray.map(rule => rule.split('\n').map(x => x.trim()).join(''));
+        const formatStyles = (styles) => styles.map(style => style.replace(/(;|{|})/g, '$1\n')).join('');
+        assert.deepEqual(
             actual,
             expectedNormalized,
             `
@@ -345,7 +346,7 @@ ${formatStyles(actual)}
                 color: 'red',
             },
             color: 'blue',
-        }], '.foo{color:blue;}.bar .foo{color:red;}', [handler], {}, false);
+        }], ['.foo{color:blue;}','.bar .foo{color:red;}'], [handler], {}, false);
     });
 
     it('correctly prefixes border-color transition properties', () => {

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -274,17 +274,17 @@ ${formatStyles(actual)}
                     padding: 30,
                 }
             }
-        ], `
-        @media (min-width: 200px){
+        ], [
+            `@media (min-width: 200px){
             .foo{
                 padding:20px !important;
             }
-        }
-        @media (min-width: 400px){
+        }`,
+            `@media (min-width: 400px){
             .foo{
                 padding:30px !important;
             }
-        }`, defaultSelectorHandlers);
+        }`], defaultSelectorHandlers);
     });
 
     it('supports custom string handlers', () => {

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -9,6 +9,7 @@ import {
   css
 } from '../src/index.js';
 import { reset } from '../src/inject.js';
+import { getSheetText } from './testUtils.js';
 
 describe('css', () => {
     beforeEach(() => {
@@ -80,9 +81,10 @@ describe('css', () => {
         asap(() => {
             const styleTags = global.document.getElementsByTagName("style");
             const lastTag = styleTags[styleTags.length - 1];
+            const style = getSheetText(lastTag.sheet);
 
-            assert.include(lastTag.textContent, `${sheet.red._name}{`);
-            assert.match(lastTag.textContent, /color:red !important/);
+            assert.include(style, `${sheet.red._name} {`);
+            assert.match(style, /color: red !important/);
             done();
         });
     });
@@ -132,10 +134,10 @@ describe('css', () => {
         asap(() => {
             const styleTags = global.document.getElementsByTagName("style");
             assert.equal(styleTags.length, 1);
-            const styles = styleTags[0].textContent;
+            const styles = getSheetText(styleTags[0].sheet);
 
-            assert.include(styles, `${sheet.red._name}{`);
-            assert.include(styles, 'color:red');
+            assert.include(styles, `${sheet.red._name} {`);
+            assert.include(styles, 'color: red');
 
             done();
         });
@@ -292,14 +294,14 @@ describe('rehydrate', () => {
         asap(() => {
             const styleTags = global.document.getElementsByTagName("style");
             assert.equal(styleTags.length, 1);
-            const styles = styleTags[0].textContent;
+            const styles = getSheetText(styleTags[0].sheet);
 
-            assert.notInclude(styles, `.${sheet.red._name}{`);
-            assert.notInclude(styles, `.${sheet.blue._name}{`);
-            assert.include(styles, `.${sheet.green._name}{`);
-            assert.notMatch(styles, /color:blue/);
-            assert.notMatch(styles, /color:red/);
-            assert.match(styles, /color:green/);
+            assert.notInclude(styles, `.${sheet.red._name} {`);
+            assert.notInclude(styles, `.${sheet.blue._name} {`);
+            assert.include(styles, `.${sheet.green._name} {`);
+            assert.notMatch(styles, /color: blue/);
+            assert.notMatch(styles, /color: red/);
+            assert.match(styles, /color: green/);
 
             done();
         });
@@ -364,14 +366,14 @@ describe('StyleSheet.extend', () => {
         asap(() => {
             const styleTags = global.document.getElementsByTagName("style");
             assert.equal(styleTags.length, 1);
-            const styles = styleTags[0].textContent;
+            const styles = getSheetText(styleTags[0].sheet);
 
             assert.notInclude(styles, '^bar');
             assert.include(styles, '.bar .foo');
             assert.include(styles, '.baz .bar .foo');
-            assert.include(styles, 'color:red');
-            assert.include(styles, 'color:blue');
-            assert.include(styles, 'color:orange');
+            assert.include(styles, 'color: red');
+            assert.include(styles, 'color: blue');
+            assert.include(styles, 'color: orange');
 
             done();
         });

--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -464,9 +464,9 @@ describe('String handlers', () => {
             flushToStyleTag();
 
             assertStylesInclude('@keyframes keyframe_d35t13');
-            assertStylesInclude('0%{opacity:0;-webkit-transform:scale(0.75) translate3d(1px, 2px, 0);-ms-transform:scale(0.75) translate3d(1px, 2px, 0);transform:scale(0.75) translate3d(1px, 2px, 0);}');
-            assertStylesInclude('100%{opacity:1;-webkit-transform:scale(1) translate3d(1px, 2px, 0);-ms-transform:scale(1) translate3d(1px, 2px, 0);transform:scale(1) translate3d(1px, 2px, 0);}');
-            assertStylesInclude('animation-name:keyframe_d35t13');
+            assertStylesInclude('0% {opacity: 0; -webkit-transform: scale(0.75) translate3d(1px,2px,0); -ms-transform: scale(0.75) translate3d(1px,2px,0); transform: scale(0.75) translate3d(1px,2px,0);}');
+            assertStylesInclude('100% {opacity: 1; -webkit-transform: scale(1) translate3d(1px,2px,0); -ms-transform: scale(1) translate3d(1px,2px,0); transform: scale(1) translate3d(1px,2px,0);}');
+            assertStylesInclude('animation-name: keyframe_d35t13');
         });
 
         it('doesn\'t add the same keyframes twice', () => {

--- a/tests/no-important_test.js
+++ b/tests/no-important_test.js
@@ -7,6 +7,7 @@ import {
   css
 } from '../src/no-important.js';
 import { reset } from '../src/inject.js';
+import { getSheetText } from './testUtils.js';
 
 describe('css', () => {
     beforeEach(() => {
@@ -31,10 +32,11 @@ describe('css', () => {
         asap(() => {
             const styleTags = global.document.getElementsByTagName("style");
             const lastTag = styleTags[styleTags.length - 1];
+            const styles = getSheetText(lastTag.sheet);
 
-            assert.include(lastTag.textContent, `${sheet.red._name}{`);
-            assert.match(lastTag.textContent, /color:red/);
-            assert.notMatch(lastTag.textContent, /!important/);
+            assert.include(styles, `${sheet.red._name} {`);
+            assert.match(styles, /color: red/);
+            assert.notMatch(styles, /!important/);
             done();
         });
     });

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,0 +1,7 @@
+export const getSheetText = (sheet) => {
+    let allRules = '';
+    for (let i = 0; i < sheet.cssRules.length; i ++) {
+        allRules += sheet.cssRules[i].cssText + ' ';
+    }
+    return allRules;
+};


### PR DESCRIPTION
Instead of appending a new text node to a style tag or appending to the `cssText` property of the stylesheet (which broke media queries in IE as documented in #238), use `insertRule` to add CSS rules to the `style` element.

This change requires styles to be generated as an array of strings with one rule per string, rather than a single large string that contains multiple rules.

This was (at least provisionally) implemented in  #83 and #157 and discussed in #76, but it didn't seem like those were going anywhere.