### PR TITLE
RunKit example: simplify output

### DIFF
--- a/examples/runkit.js
+++ b/examples/runkit.js
@@ -29,5 +29,4 @@ const {css, html} = StyleSheetServer.renderStatic(() => {
 });
 
 // Observe our output HTML and the Aphrodite-generated CSS
-console.log("Output HTML:", html);
-console.log("Output CSS:", css.content);
+`<style>${css.content}</style>${html}`;


### PR DESCRIPTION
Collapse `console.log`s via a template literal so that the HTML with CSS is rendered in the RunKit result. RunKit behaves like a REPL so the last value is returned.

The existing [RunKit example](https://npm.runkit.com/aphrodite) is great, so this just takes it slightly further so you can see how your browser would render the styles that Aphrodite generates.

You can see it in action here: https://runkit.com/pieter/aphrodite-runkit-example

### Before
![screen shot 2017-06-06 at 11 34 07 am](https://user-images.githubusercontent.com/101547/26845817-956db7a6-4aac-11e7-9573-e384025d0e73.png)

### After
![screen shot 2017-06-06 at 11 34 47 am](https://user-images.githubusercontent.com/101547/26845816-955ca1be-4aac-11e7-8e6f-7e9d7af1d5a7.png)

