### PR TITLE
[createClassUID] Minify combined classNames

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -21,9 +21,7 @@ const StyleSheet = {
     create(sheetDefinition /* : SheetDefinition */) {
         return mapObj(sheetDefinition, ([key, val]) => {
             return [key, {
-                // TODO(gil): Further minify the -O_o--combined hashes
-                _name: process.env.NODE_ENV === 'production' ?
-                    `_${hashObject(val)}` : `${key}_${hashObject(val)}`,
+                _name: `${key}_${hashObject(val)}`,
                 _definition: val
             }];
         });

--- a/src/util.js
+++ b/src/util.js
@@ -133,7 +133,6 @@ export const stringifyAndImportantifyValue = (
 // can probably depend on this too.
 export const hashObject = (object /* : ObjectMap */) /* : string */ => stringHash(JSON.stringify(object)).toString(36);
 
-
 // Given a single style value string like the "b" from "a: b;", adds !important
 // to generate "b !important".
 const importantify = (string /* : string */) /* : string */ => (


### PR DESCRIPTION
I'll add specs if there are no major concerns with this approach. The minified classNames for production are generated sequentially (base 36) instead of using a hash. The first class name is always `_1`, then `_2` and so on...

@lencioni 
@xymostech 
@jlfwong 
