### PR TITLE
Fix fontFamily being set to undefined

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -64,8 +64,21 @@ const stringHandlers = {
         if (Array.isArray(val)) {
             return val.map(fontFamily).join(",");
         } else if (typeof val === "object") {
-            injectStyleOnce(val.src, "@font-face", [val], false);
-            return `"${val.fontFamily}"`;
+            let key = val.src;
+            let fontFamily = val.fontFamily;
+
+            // More than likely this object will be an OrderedElement type
+            // which will require usage of its getters methods
+            if (val instanceof OrderedElements) {
+                // We need to generate a unique key by which we can identify
+                // this declaration in the the 'alreadyInjected' object
+                key = `fontface_${hashObject(val)}`;
+                fontFamily = val.get('fontFamily');
+            }
+
+            injectStyleOnce(key, "@font-face", [val], false);
+
+            return `"${fontFamily}"`;
         } else {
             return val;
         }


### PR DESCRIPTION
Added a check for an `instanceof` `OrderedElement` for the `fontFamily` `StringHandler` helper function.

There was a check if the value passed was an _Array_, _Object_ or _String_. When it was an _Object_ it keys were accessed directly. But Objects of type `OrderedElement` have a different shape. I added a check if it was of type `OrderedElement` and so go about using it's getter function `OrderedElement.get()` otherwise just on the object directly.