### PR TITLE
Updated Typescript definitions and included in package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,3 @@ declare module "aphrodite" {
         extend( extensions: Extension[] ): Exports;
     }
 }
-
-declare module "aphrodite/no-important" {
-    export * from "aphrodite";
-}

--- a/no-important.d.ts
+++ b/no-important.d.ts
@@ -1,0 +1,1 @@
+export * from "aphrodite";

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "inline-styles"
   ],
   "main": "lib/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint --fix --cache . && flow check",
     "test": "npm run coverage",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "inline-styles"
   ],
   "main": "lib/index.js",
-  "types": "types/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint --fix --cache . && flow check",
     "test": "npm run coverage",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,109 @@
+// Type definitions for Aphrodite 1.2.3
+// Project: https://github.com/Khan/aphrodite
+
+declare module "aphrodite" {
+    import * as React from "react";
+
+    /**
+     * Aphrodite style declaration
+     */
+    export interface StyleDeclaration
+    {
+        [key: string]: React.CSSProperties;
+    }
+
+    interface StyleSheetStatic
+    {
+        /**
+         * Create style sheet
+         */
+        create( styles: StyleDeclaration ): StyleDeclaration;
+        create<T extends StyleDeclaration>( styles: T ): T;
+        /**
+         * Rehydrate class names from server renderer
+         */
+        rehydrate( renderedClassNames: string[] ): void;
+    }
+
+    export var StyleSheet: StyleSheetStatic;
+
+    type CSSInputTypes = ( StyleDeclaration | false | null | void );
+
+    /**
+     * Get class names from passed styles
+     */
+    export function css( ...styles: CSSInputTypes[] ): string;
+
+    interface StaticRendererResult
+    {
+        html: string;
+        css: {
+            content: string;
+            renderedClassNames: string[];
+        }
+    }
+
+    /**
+     * Utilities for using Aphrodite server-side.
+     */
+    interface StyleSheetServerStatic
+    {
+        renderStatic( renderFunc: () => string ): StaticRendererResult;
+    }
+
+    export var StyleSheetServer: StyleSheetServerStatic;
+
+    interface StyleSheetTestUtilsStatic
+    {
+        /**
+         * Prevent styles from being injected into the DOM.
+         *
+         * This is useful in situations where you'd like to test rendering UI
+         * components which use Aphrodite without any of the side-effects of
+         * Aphrodite happening. Particularly useful for testing the output of
+         * components when you have no DOM, e.g. testing in Node without a fake DOM.
+         *
+         * Should be paired with a subsequent call to
+         * clearBufferAndResumeStyleInjection.
+         */
+        suppressStyleInjection(): void;
+        /**
+         * Opposite method of preventStyleInject.
+        */
+        clearBufferAndResumeStyleInjection(): void;
+    }
+
+    export var StyleSheetTestUtils: StyleSheetTestUtilsStatic;
+
+    export interface SelectorHandler
+    {
+        ( selector: string, baseSelector: string, callback: ( selector: string ) => string ): string | null;
+    }
+
+    export interface Extension
+    {
+        selectorHandler?: SelectorHandler,
+    }
+
+    /**
+     * Calling StyleSheet.extend() returns an object with each of the exported
+     * properties on it.
+     */
+    interface Exports
+    {
+        css( ...styles: CSSInputTypes[] ): string;
+
+        StyleSheet: StyleSheetStatic;
+        StyleSheetServer: StyleSheetServerStatic;
+        StyleSheetTestUtils: StyleSheetTestUtilsStatic;
+    }
+
+    interface StyleSheetStatic
+    {
+        extend( extensions: Extension[] ): Exports;
+    }
+}
+
+declare module "aphrodite/no-important" {
+    export * from "aphrodite";
+}


### PR DESCRIPTION
It seems that https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12845 kinda died on the vine.

So, I took the .d.ts file from that PR, tweaked it a little bit by:
*  adding an overload to "create" (makes intellisense a bit happier in the default case)
*  changing the parameter type for "css" to model after the Flow type (instead of just "any")

Since you can just include a .d.ts file in your package.json and Typescript will pick it up, I figured that would be the lowest friction distribution method, if you're cool with that.