### PR TITLE
Add tests for keyframes with multiple properties

### DIFF
--- a/tests/inject_test.js
+++ b/tests/inject_test.js
@@ -441,6 +441,32 @@ describe('String handlers', () => {
             assertStylesInclude('animation-name:keyframe_tmjr6');
         });
 
+        it('generates css for keyframes with multiple properties', () => {
+            const sheet = StyleSheet.create({
+                animate: {
+                    animationName: {
+                        '0%': {
+                            opacity: 0,
+                            transform: 'scale(0.75) translate3d(1px, 2px, 0)',
+                        },
+                        '100%': {
+                            opacity: 1,
+                            transform: 'scale(1) translate3d(1px, 2px, 0)',
+                        },
+                    },
+                },
+            });
+
+            startBuffering();
+            css(sheet.animate);
+            flushToStyleTag();
+
+            assertStylesInclude('@keyframes keyframe_d35t13');
+            assertStylesInclude('0%{opacity:0;-webkit-transform:scale(0.75) translate3d(1px, 2px, 0);-ms-transform:scale(0.75) translate3d(1px, 2px, 0);transform:scale(0.75) translate3d(1px, 2px, 0);}');
+            assertStylesInclude('100%{opacity:1;-webkit-transform:scale(1) translate3d(1px, 2px, 0);-ms-transform:scale(1) translate3d(1px, 2px, 0);transform:scale(1) translate3d(1px, 2px, 0);}');
+            assertStylesInclude('animation-name:keyframe_d35t13');
+        });
+
         it('doesn\'t add the same keyframes twice', () => {
             const keyframes = {
                 'from': {


### PR DESCRIPTION
I was investigating a bug and wanted to have concrete proof that it was
not present in Aphrodite, so I wrote this test. Since I took the time to
write it, I figured I might as well commit it up.