### PR TITLE
Allow overridden styles to re-order in generated CSS

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -199,9 +199,9 @@ const runStringHandlers = (
     declarations /* : OrderedElements */,
     stringHandlers /* : StringHandlers */,
     selectorHandlers /* : SelectorHandler[] */
-) /* : OrderedElements */ => {
+) /* : void */ => {
     if (!stringHandlers) {
-        return declarations;
+        return;
     }
 
     const stringHandlerKeys = Object.keys(stringHandlers);
@@ -223,8 +223,6 @@ const runStringHandlers = (
             );
         }
     }
-
-    return declarations;
 };
 
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -177,7 +177,7 @@ export const generateCSS = (
         // If none of the handlers handled it, add it to the list of plain
         // style declarations.
         if (!foundHandler) {
-            plainDeclarations.set(key, val);
+            plainDeclarations.set(key, val, true);
         }
     });
 
@@ -224,7 +224,7 @@ const runStringHandlers = (
                 // Preserve order here, since we are really replacing an
                 // unprocessed style with a processed style, not overriding an
                 // earlier style
-                true
+                false
             );
         }
     }

--- a/src/generate.js
+++ b/src/generate.js
@@ -219,7 +219,12 @@ const runStringHandlers = (
             // handlers are very specialized and do complex things.
             declarations.set(
                 key,
-                stringHandlers[key](declarations.get(key), selectorHandlers)
+                stringHandlers[key](declarations.get(key), selectorHandlers),
+
+                // Preserve order here, since we are really replacing an
+                // unprocessed style with a processed style, not overriding an
+                // earlier style
+                true
             );
         }
     }

--- a/src/ordered-elements.js
+++ b/src/ordered-elements.js
@@ -19,10 +19,10 @@ export default class OrderedElements {
         }
     }
 
-    set(key /* : string */, value /* : any */, preserveOrder /* : ?boolean */) {
+    set(key /* : string */, value /* : any */, shouldReorder /* : ?boolean */) {
         if (!this.elements.hasOwnProperty(key)) {
             this.keyOrder.push(key);
-        } else if (!preserveOrder) {
+        } else if (shouldReorder) {
             const index = this.keyOrder.indexOf(key);
             this.keyOrder.splice(index, 1);
             this.keyOrder.push(key);
@@ -40,7 +40,7 @@ export default class OrderedElements {
                 ? this.elements[key]
                 : new OrderedElements();
             value.forEach((value, key) => {
-                nested.set(key, value);
+                nested.set(key, value, shouldReorder);
             });
             this.elements[key] = nested;
             return;
@@ -54,7 +54,7 @@ export default class OrderedElements {
                 : new OrderedElements();
             const keys = Object.keys(value);
             for (let i = 0; i < keys.length; i += 1) {
-                nested.set(keys[i], value[keys[i]]);
+                nested.set(keys[i], value[keys[i]], shouldReorder);
             }
             this.elements[key] = nested;
             return;
@@ -74,12 +74,12 @@ export default class OrderedElements {
     addStyleType(styleType /* : any */) /* : void */ {
         if ((MAP_EXISTS && styleType instanceof Map) || styleType instanceof OrderedElements) {
             styleType.forEach((value, key) => {
-                this.set(key, value);
+                this.set(key, value, true);
             });
         } else {
             const keys = Object.keys(styleType);
             for (let i = 0; i < keys.length; i++) {
-                this.set(keys[i], styleType[keys[i]]);
+                this.set(keys[i], styleType[keys[i]], true);
             }
         }
     }

--- a/src/ordered-elements.js
+++ b/src/ordered-elements.js
@@ -19,8 +19,12 @@ export default class OrderedElements {
         }
     }
 
-    set(key /* : string */, value /* : any */) {
+    set(key /* : string */, value /* : any */, preserveOrder /* : ?boolean */) {
         if (!this.elements.hasOwnProperty(key)) {
+            this.keyOrder.push(key);
+        } else if (!preserveOrder) {
+            const index = this.keyOrder.indexOf(key);
+            this.keyOrder.splice(index, 1);
             this.keyOrder.push(key);
         }
 

--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -258,6 +258,34 @@ ${formatStyles(actual)}
         }`, defaultSelectorHandlers);
     });
 
+    it('orders overrides in the expected way', () => {
+        assertCSS('.foo', [
+            {
+                "@media (min-width: 400px)": {
+                    padding: 10,
+                }
+            },
+            {
+                "@media (min-width: 200px)": {
+                    padding: 20,
+                },
+                "@media (min-width: 400px)": {
+                    padding: 30,
+                }
+            }
+        ], `
+        @media (min-width: 200px){
+            .foo{
+                padding:20px !important;
+            }
+        }
+        @media (min-width: 400px){
+            .foo{
+                padding:30px !important;
+            }
+        }`, defaultSelectorHandlers);
+    });
+
     it('supports custom string handlers', () => {
         assertCSS('.foo', [{
             fontFamily: ["Helvetica", "sans-serif"]

--- a/tests/ordered-elements_test.js
+++ b/tests/ordered-elements_test.js
@@ -53,6 +53,38 @@ describe("OrderedElements", () => {
         }, elems);
     });
 
+    it('moves overridden elements to the end', () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("b", 1);
+        elems.set("a", 2);
+
+        assert.deepEqual({
+            elements: {
+                b: 1,
+                a: 2,
+            },
+            keyOrder: ["b", "a"],
+        }, elems);
+    });
+
+    it('can preserve order when setting', () => {
+        const elems = new OrderedElements();
+
+        elems.set("a", 1);
+        elems.set("b", 1);
+        elems.set("a", 2, true);
+
+        assert.deepEqual({
+            elements: {
+                a: 2,
+                b: 1,
+            },
+            keyOrder: ["a", "b"],
+        }, elems);
+    });
+
     it("iterates over the elements in the correct order", () => {
         const elems = new OrderedElements();
 

--- a/tests/ordered-elements_test.js
+++ b/tests/ordered-elements_test.js
@@ -53,7 +53,7 @@ describe("OrderedElements", () => {
         }, elems);
     });
 
-    it('moves overridden elements to the end', () => {
+    it('preserves original order when overriding', () => {
         const elems = new OrderedElements();
 
         elems.set("a", 1);
@@ -62,14 +62,14 @@ describe("OrderedElements", () => {
 
         assert.deepEqual({
             elements: {
-                b: 1,
                 a: 2,
+                b: 1,
             },
-            keyOrder: ["b", "a"],
+            keyOrder: ["a", "b"],
         }, elems);
     });
 
-    it('can preserve order when setting', () => {
+    it('can reorder when overriding', () => {
         const elems = new OrderedElements();
 
         elems.set("a", 1);
@@ -78,10 +78,10 @@ describe("OrderedElements", () => {
 
         assert.deepEqual({
             elements: {
-                a: 2,
                 b: 1,
+                a: 2,
             },
-            keyOrder: ["a", "b"],
+            keyOrder: ["b", "a"],
         }, elems);
     });
 


### PR DESCRIPTION
We ran into a weird scenario, where if you passed the following two
objects to css() in this order:

```js
{
  '@media all and (min-width: 1128px)': {},
},
{
  '@media all and (min-width: 744px)': {
    backgroundColor: 'red',
  },
  '@media all and (min-width: 1128px)': {
    backgroundColor: 'blue',
  },
}
```

you would normally expect it to produce a style that has the 744px
min-width media query first. Unfortunately, because the first object
already had that media query as an ordered key in its OrderedElements
object, it maintained its original position. This caused the 1128px
media query to be output first, which is unexpected and ended up causing
a visual bug.

To fix this, I modified OrderedElements to always move overridden keys
to the end. This now behaves more like you would expect regular CSS to
work.

I needed to add a special case for string handlers, since they aren't
actually overriding a style but rather replacing a property with a newly
computed value.

cc @DanielGarcia-Carrillo