### PR TITLE
Add minify global function to force style names minification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Aphrodite: Inline Styles that work
 
-[![npm version](https://badge.fury.io/js/aphrodite.svg)](https://badge.fury.io/js/aphrodite) 
-[![Build Status](https://travis-ci.org/Khan/aphrodite.svg?branch=master)](https://travis-ci.org/Khan/aphrodite) 
-[![Coverage Status](https://coveralls.io/repos/github/Khan/aphrodite/badge.svg?branch=master)](https://coveralls.io/github/Khan/aphrodite?branch=master) 
+[![npm version](https://badge.fury.io/js/aphrodite.svg)](https://badge.fury.io/js/aphrodite)
+[![Build Status](https://travis-ci.org/Khan/aphrodite.svg?branch=master)](https://travis-ci.org/Khan/aphrodite)
+[![Coverage Status](https://coveralls.io/repos/github/Khan/aphrodite/badge.svg?branch=master)](https://coveralls.io/github/Khan/aphrodite?branch=master)
 [![Gitter chat](https://img.shields.io/gitter/room/Khan/aphrodite.svg)](https://gitter.im/Khan/aphrodite)
 
 [![gzip size][gzip-badge]][unpkg-dist]
@@ -183,6 +183,23 @@ to avoid this behaviour, then instead of importing `aphrodite`, import
 
 ```js
 import { StyleSheet, css } from 'aphrodite/no-important';
+```
+
+## Minifying style names
+
+By default, Aphrodite will minify style names down to their hashes in production
+(`process.env.NODE_ENV === 'production'`). You can override this behavior by
+calling `minify` with `true` or `false` before calling `StyleSheet.create`.
+
+This is useful if you want to facilitate debugging in production for example.
+
+```js
+import { StyleSheet, minify } from 'aphrodite';
+
+// Always keep the full style names
+minify(false);
+
+// ... proceed to use StyleSheet.create etc.
 ```
 
 ## Font Faces

--- a/src/exports.js
+++ b/src/exports.js
@@ -17,13 +17,26 @@ type Extension = {
 export type MaybeSheetDefinition = SheetDefinition | false | null | void
 */
 
+// True to minify classnames.
+// False to not minify classnames.
+// Unset to minify only in 'production' environment
+let forceMinify = undefined;
+const shouldMinify = () => {
+    if (forceMinify !== undefined) {
+        return forceMinify;
+    } else {
+        return process.env.NODE_ENV === 'production';
+    }
+}
+
+
 const StyleSheet = {
     create(sheetDefinition /* : SheetDefinition */) {
         return mapObj(sheetDefinition, ([key, val]) => {
             const stringVal = JSON.stringify(val);
             return [key, {
                 _len: stringVal.length,
-                _name: process.env.NODE_ENV === 'production' ?
+                _name: shouldMinify() ?
                     hashString(stringVal) : `${key}_${hashString(stringVal)}`,
                 _definition: val
             }];
@@ -130,6 +143,10 @@ const makeExports = (
 
         StyleSheetServer,
         StyleSheetTestUtils,
+
+        minify(shouldMinify /* : boolean */) {
+            forceMinify = shouldMinify;
+        },
 
         css(...styleDefinitions /* : MaybeSheetDefinition[] */) {
             return injectAndGetClassName(

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   StyleSheetServer,
   StyleSheetTestUtils,
+  minify,
   css
 } from '../src/index.js';
 import { reset } from '../src/inject.js';
@@ -253,6 +254,76 @@ describe('StyleSheet.create', () => {
             });
 
             assert.equal(sheet.test._name, 'j5rvvh');
+        });
+    })
+});
+
+describe('minify', () => {
+    describe('true', () => {
+        beforeEach(() => {
+            minify(true);
+        });
+
+        afterEach(() => {
+            minify(undefined);
+        });
+
+        it('minifies style names', () => {
+            const sheet = StyleSheet.create({
+                test: {
+                    color: 'red',
+                    height: 20,
+
+                    ':hover': {
+                        color: 'blue',
+                        width: 40,
+                    },
+                },
+            });
+
+            assert.equal(sheet.test._name, 'j5rvvh');
+        });
+    })
+
+    describe('false', () => {
+        beforeEach(() => {
+            minify(false);
+        });
+
+        afterEach(() => {
+            minify(undefined);
+        });
+
+        it('does not minifies style names', () => {
+            const sheet = StyleSheet.create({
+                test: {
+                    color: 'red',
+                    height: 20,
+
+                    ':hover': {
+                        color: 'blue',
+                        width: 40,
+                    },
+                },
+            });
+
+            assert.equal(sheet.test._name, 'test_j5rvvh');
+        });
+
+        it('does not minifies style names, even with process.env.NODE_ENV === \'production\'', () => {
+            const sheet = StyleSheet.create({
+                test: {
+                    color: 'red',
+                    height: 20,
+
+                    ':hover': {
+                        color: 'blue',
+                        width: 40,
+                    },
+                },
+            });
+
+            assert.equal(sheet.test._name, 'test_j5rvvh');
         });
     })
 });


### PR DESCRIPTION
Fix #288 

This exports a global function `minify` that can be called to control the minification of style names, independently of the `NODE_ENV` environment value.

Call `minify(false)` before using `StyleSheet.create` to never minify style names. Call `minify(true)` to always minify style names. Defaults to the current behavior of minifying only if `process.env.NODE_ENV === 'production'`.