### PR TITLE
Add method to get string value of buffered styles during testing

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -4,6 +4,7 @@ import {
     injectAndGetClassName,
     reset, startBuffering, flushToString,
     addRenderedClassNames, getRenderedClassNames,
+    getBufferedStyles,
 } from './inject';
 
 /* ::
@@ -83,6 +84,15 @@ const StyleSheetTestUtils = {
     clearBufferAndResumeStyleInjection() {
         reset();
     },
+
+    /**
+     * Returns a string of buffered styles which have not been flushed
+     *
+     * @returns {string}  Buffer of styles which have not yet been flushed.
+     */
+    getBufferedStyles() {
+        return getBufferedStyles();
+    }
 };
 
 /**

--- a/src/inject.js
+++ b/src/inject.js
@@ -192,6 +192,10 @@ export const reset = () => {
     styleTag = null;
 };
 
+export const getBufferedStyles = () => {
+    return injectionBuffer;
+}
+
 export const startBuffering = () => {
     if (isBuffering) {
         throw new Error(

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -532,3 +532,27 @@ describe('StyleSheetTestUtils.suppressStyleInjection', () => {
         asap(done);
     });
 });
+
+describe('StyleSheetTestUtils.getBufferedStyles', () => {
+    beforeEach(() => {
+        StyleSheetTestUtils.suppressStyleInjection();
+    });
+
+    afterEach(() => {
+        StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+    });
+
+    it('returns injection buffer', () => {
+        const sheet = StyleSheet.create({
+            red: {
+                color: 'red',
+            },
+        });
+        css(sheet.red);
+        asap(() => {
+            const buffer = StyleSheetTestUtils.getBufferedStyles();
+            assert.include(buffer, 'color:red');
+            assert.include(buffer, sheet.red._name);
+        })
+    });
+});


### PR DESCRIPTION
Fixes #293 Add method to get the string value of buffered styles during testing. This will allow for creating a tool for more detailed snapshots.