### PR TITLE
Bump inline-style-prefixer to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aphrodite",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -548,11 +548,6 @@
         "hoek": "2.16.3"
       }
     },
-    "bowser": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.7.1.tgz",
-      "integrity": "sha1-pN6PGKGg3JUx6yqSoVIftqm6lqU="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -939,14 +934,6 @@
         "pbkdf2-compat": "2.0.1",
         "ripemd160": "0.2.0",
         "sha.js": "2.2.6"
-      }
-    },
-    "css-in-js-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz",
-      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU=",
-      "requires": {
-        "hyphenate-style-name": "1.0.2"
       }
     },
     "cssom": {
@@ -2639,15 +2626,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2657,6 +2635,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3071,12 +3058,27 @@
       "dev": true
     },
     "inline-style-prefixer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz",
-      "integrity": "sha1-Nn2eDuJn4z7i9W1rIcwsU56S5kk=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.0.tgz",
+      "integrity": "sha1-MKA98bNGumsfuKgSvDydq+9IAi0=",
       "requires": {
-        "bowser": "1.7.1",
-        "css-in-js-utils": "1.0.3"
+        "bowser": "1.9.2",
+        "css-in-js-utils": "2.0.0"
+      },
+      "dependencies": {
+        "bowser": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.2.tgz",
+          "integrity": "sha512-fuiANC1Bqbqa/S4gmvfCt7bGBmNELMsGZj4Wg3PrP6esP66Ttoj1JSlzFlXtHyduMv07kDNmDsX6VsMWT/MLGg=="
+        },
+        "css-in-js-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
+          "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
+          "requires": {
+            "hyphenate-style-name": "1.0.2"
+          }
+        }
       }
     },
     "inquirer": {
@@ -7150,15 +7152,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
@@ -7184,6 +7177,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringmap": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "asap": "^2.0.3",
-    "inline-style-prefixer": "^3.0.1",
+    "inline-style-prefixer": "^4.0.0",
     "string-hash": "^1.1.3"
   },
   "tonicExampleFilename": "examples/runkit.js",


### PR DESCRIPTION
This bumps the version of [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer) to pick up the bug fixes and performance improvements introduced since 3.0.1, which includes a reported 30% improvement. From what I can tell, the major version bump was due to them changing their default browser prefix list, which we specify our own in https://github.com/Khan/aphrodite/blob/master/tools/generate_prefixer_data.js so I don't believe that will be an issue. https://github.com/rofrischmann/inline-style-prefixer/blob/master/Changelog.md