### PR TITLE
Fix export of minify global function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const {
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
+    minify,
 } = Aphrodite;
 
 export {
@@ -20,4 +21,5 @@ export {
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
+    minify,
 };


### PR DESCRIPTION
Fix error following merge of the `minify` PR. The way `index.js` exports were made has been changed on `master` since I had started the PR.
See https://github.com/Khan/aphrodite/pull/291#issuecomment-365788953