### PR TITLE
Replace object spread a reduce in generateCSSRuleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Aphrodite is distributed via [npm](https://www.npmjs.com/):
 npm install --save aphrodite
 ```
 
+# Requirements
+
+`Set` needs to be available or polyfilled.
+
 # API
 
 If you'd rather watch introductory videos, you can find them [here](https://www.youtube.com/playlist?list=PLo4Zh55ZzNSBP78pCD0dZJi9zf8CA72_M).

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Aphrodite is distributed via [npm](https://www.npmjs.com/):
 npm install --save aphrodite
 ```
 
-# Requirements
-
-`Set` needs to be available or polyfilled.
-
 # API
 
 If you'd rather watch introductory videos, you can find them [here](https://www.youtube.com/playlist?list=PLo4Zh55ZzNSBP78pCD0dZJi9zf8CA72_M).

--- a/src/generate.js
+++ b/src/generate.js
@@ -250,6 +250,11 @@ const transformRule = (
 );
 
 
+const arrayToObjectKeysReducer = (acc, val) => {
+    acc[val] = true;
+    return acc;
+};
+
 /**
  * Generate a CSS ruleset with the selector and containing the declarations.
  *
@@ -291,7 +296,8 @@ export const generateCSSRuleset = (
     // Mutates declarations
     runStringHandlers(declarations, stringHandlers, selectorHandlers);
 
-    const originalElements = new Set(Object.keys(declarations.elements));
+    const originalElements = Object.keys(declarations.elements)
+        .reduce(arrayToObjectKeysReducer, Object.create(null));
 
     // NOTE(emily): This mutates handledDeclarations.elements.
     const prefixedElements = prefixAll(declarations.elements);
@@ -305,7 +311,7 @@ export const generateCSSRuleset = (
         // sortOrder, which means it was added by prefixAll. This means that we
         // need to figure out where it should appear in the sortOrder.
         for (let i = 0; i < elementNames.length; i++) {
-            if (!originalElements.has(elementNames[i])) {
+            if (!originalElements[elementNames[i]]) {
                 // This element is not in the sortOrder, which means it is a prefixed
                 // value that was added by prefixAll. Let's try to figure out where it
                 // goes.
@@ -324,7 +330,7 @@ export const generateCSSRuleset = (
                     originalStyle = elementNames[i][2].toLowerCase() + elementNames[i].slice(3);
                 }
 
-                if (originalStyle && originalElements.has(originalStyle)) {
+                if (originalStyle && originalElements[originalStyle]) {
                     const originalIndex = declarations.keyOrder.indexOf(originalStyle);
                     declarations.keyOrder.splice(originalIndex, 0, elementNames[i]);
                 } else {

--- a/src/generate.js
+++ b/src/generate.js
@@ -291,7 +291,7 @@ export const generateCSSRuleset = (
     // Mutates declarations
     runStringHandlers(declarations, stringHandlers, selectorHandlers);
 
-    const originalElements = {...declarations.elements};
+    const originalElements = new Set(Object.keys(declarations.elements));
 
     // NOTE(emily): This mutates handledDeclarations.elements.
     const prefixedElements = prefixAll(declarations.elements);
@@ -305,7 +305,7 @@ export const generateCSSRuleset = (
         // sortOrder, which means it was added by prefixAll. This means that we
         // need to figure out where it should appear in the sortOrder.
         for (let i = 0; i < elementNames.length; i++) {
-            if (!originalElements.hasOwnProperty(elementNames[i])) {
+            if (!originalElements.has(elementNames[i])) {
                 // This element is not in the sortOrder, which means it is a prefixed
                 // value that was added by prefixAll. Let's try to figure out where it
                 // goes.
@@ -324,7 +324,7 @@ export const generateCSSRuleset = (
                     originalStyle = elementNames[i][2].toLowerCase() + elementNames[i].slice(3);
                 }
 
-                if (originalStyle && originalElements.hasOwnProperty(originalStyle)) {
+                if (originalStyle && originalElements.has(originalStyle)) {
                     const originalIndex = declarations.keyOrder.indexOf(originalStyle);
                     declarations.keyOrder.splice(originalIndex, 0, elementNames[i]);
                 } else {


### PR DESCRIPTION
I was profiling Aphrodite and noticed that the self time in
generateCSSRuleset is one of the most expensive bits. Digging in a bit,
it looked like most of this was coming from the object spread here,
which we use do copy the original object so we can reference its keys
with fast lookups. By swapping this out for a ~Set~ reduce we greatly reduce the
self time of this function from ~7% of total runtime to ~3%.

~I've implemented this in a way that expects Set to be available in the
browser or polyfilled, which I think is a reasonable explanation. I've
documented this in the readme. If we move forward with this, we could
also make Map a requirement and simplify a couple of codepaths if we
want.~