### PR TITLE
Allow StyleSheetServer to be minified out in client-only bundles, and StyleSheetTestUtils to be minified out in production

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -58,23 +58,32 @@ const StyleSheet = {
 
 /**
  * Utilities for using Aphrodite server-side.
+ *
+ * This can be minified out in client-only bundles by replacing `typeof window`
+ * with `"object"`, e.g. via Webpack's DefinePlugin:
+ *
+ *   new webpack.DefinePlugin({
+ *     "typeof window": JSON.stringify("object")
+ *   })
  */
-const StyleSheetServer = {
-    renderStatic(renderFunc /* : RenderFunction */) {
-        reset();
-        startBuffering();
-        const html = renderFunc();
-        const cssContent = flushToString();
+const StyleSheetServer = typeof window !== 'undefined'
+    ? null
+    : {
+        renderStatic(renderFunc /* : RenderFunction */) {
+            reset();
+            startBuffering();
+            const html = renderFunc();
+            const cssContent = flushToString();
 
-        return {
-            html: html,
-            css: {
-                content: cssContent,
-                renderedClassNames: getRenderedClassNames(),
-            },
-        };
-    },
-};
+            return {
+                html: html,
+                css: {
+                    content: cssContent,
+                    renderedClassNames: getRenderedClassNames(),
+                },
+            };
+        },
+    };
 
 /**
  * Utilities for using Aphrodite in tests.

--- a/src/exports.js
+++ b/src/exports.js
@@ -81,39 +81,41 @@ const StyleSheetServer = {
  *
  * Not meant to be used in production.
  */
-const StyleSheetTestUtils = {
-    /**
-     * Prevent styles from being injected into the DOM.
-     *
-     * This is useful in situations where you'd like to test rendering UI
-     * components which use Aphrodite without any of the side-effects of
-     * Aphrodite happening. Particularly useful for testing the output of
-     * components when you have no DOM, e.g. testing in Node without a fake DOM.
-     *
-     * Should be paired with a subsequent call to
-     * clearBufferAndResumeStyleInjection.
-     */
-    suppressStyleInjection() {
-        reset();
-        startBuffering();
-    },
+const StyleSheetTestUtils = process.env.NODE_ENV === 'production'
+    ? null
+    : {
+        /**
+        * Prevent styles from being injected into the DOM.
+        *
+        * This is useful in situations where you'd like to test rendering UI
+        * components which use Aphrodite without any of the side-effects of
+        * Aphrodite happening. Particularly useful for testing the output of
+        * components when you have no DOM, e.g. testing in Node without a fake DOM.
+        *
+        * Should be paired with a subsequent call to
+        * clearBufferAndResumeStyleInjection.
+        */
+        suppressStyleInjection() {
+            reset();
+            startBuffering();
+        },
 
-    /**
-     * Opposite method of preventStyleInject.
-     */
-    clearBufferAndResumeStyleInjection() {
-        reset();
-    },
+        /**
+        * Opposite method of preventStyleInject.
+        */
+        clearBufferAndResumeStyleInjection() {
+            reset();
+        },
 
-    /**
-     * Returns a string of buffered styles which have not been flushed
-     *
-     * @returns {string}  Buffer of styles which have not yet been flushed.
-     */
-    getBufferedStyles() {
-        return getBufferedStyles();
-    }
-};
+        /**
+        * Returns a string of buffered styles which have not been flushed
+        *
+        * @returns {string}  Buffer of styles which have not yet been flushed.
+        */
+        getBufferedStyles() {
+            return getBufferedStyles();
+        }
+    };
 
 /**
  * Generate the Aphrodite API exports, with given `selectorHandlers` and


### PR DESCRIPTION
Allow StyleSheetServer to be minified out in client-only bundles

Webpack can be configured to minify out this code when building bundles
that are client-only. This can be accomplished via the DefinePlugin:

```
new webpack.DefinePlugin({
  "typeof window": JSON.stringify("object")
})
```
---
Allow StyleSheetTestUtils to be minified out in production

These should never be used in production, so let's write it in a way
that it can be minified out to further reduce bundle sizes. Not a huge
impact, but might as well squeeze out a few more bytes.
