### PR TITLE
Expose flushToStyleTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Aphrodite will automatically attempt to create a `<style>` tag in the document's
 
 To speed up injection of styles, Aphrodite will automatically try to buffer writes to this `<style>` tag so that minimum number of DOM modifications happen.
 
-Aphrodite uses [asap](https://github.com/kriskowal/asap) to schedule buffer flushing. If you measure DOM elements' dimensions in `componentDidMount` or `componentDidUpdate`, you can use `setTimeout` function to ensure all styles are injected.
+Aphrodite uses [asap](https://github.com/kriskowal/asap) to schedule buffer flushing. If you measure DOM elements' dimensions in `componentDidMount` or `componentDidUpdate`, you can use `setTimeout` or `flushToStyleTag` to ensure all styles are injected.
 
 ```js
 import { StyleSheet, css } from 'aphrodite';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {defaultSelectorHandlers} from './generate';
 import makeExports from './exports';
+import {flushToStyleTag} from './inject';
 
 const useImportant = true; // Add !important to all style definitions
 
@@ -22,4 +23,5 @@ export {
     StyleSheetTestUtils,
     css,
     minify,
+    flushToStyleTag,
 };


### PR DESCRIPTION
v2 switched from webpack to rollup for its build. As part of this, the
individual files that were previously importable by intrepid spirits
gave access to some functions that were not explicitly exposed as part
of Aphrodite's public API.

At least one of these is cited in some issues as a workaround for some
edge cases like #76, and is used by projects like
react-with-styles-interface-aphrodite to allow folks to work around some
of these same types of issues.

To allow folks relying on this function to update to v2, I am adding
this as an export.

There may be other functions like this that we'll want to explicitly expose.