### PR TITLE
docs(README): Add jest-aphrodite-react to tools listed on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ to the string value `production`.
 # Tools
 
 - [Aphrodite output tool](https://output.jsbin.com/qoseye) - Paste what you pass to `StyleSheet.create` and see the generated CSS
+- [jest-aphrodite-react](https://github.com/dmiller9911/jest-aphrodite-react) - Utilities for testing with React and Jest.
 
 # TODO
 


### PR DESCRIPTION
I created a tool inspired by the snapshot tools provided for [styled-components](https://github.com/styled-components/jest-styled-components#snapshot-testing) and [glamorous](https://github.com/kentcdodds/jest-glamor-react).  I was hoping to put it into the README for others looking to optimize snapshots with jest/react.