### PR TITLE
fix(no-important): Fixes #311 Adds minify and flushToStyleTag to no-important

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-preset-airbnb": "^2.4.0",
     "babel-register": "^6.26.0",
     "caniuse-api": "^2.0.0",
-    "chai": "^3.3.0",
+    "chai": "^4.1.2",
     "coveralls": "^2.12.0",
     "cross-env": "^5.1.3",
     "cross-spawn": "^6.0.4",

--- a/src/no-important.js
+++ b/src/no-important.js
@@ -4,6 +4,7 @@
 // appended to them.
 import {defaultSelectorHandlers} from './generate';
 import makeExports from './exports';
+import {flushToStyleTag} from './inject';
 
 const useImportant = false; // Don't add !important to style definitions
 
@@ -17,6 +18,7 @@ const {
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
+    minify
 } = Aphrodite;
 
 export {
@@ -24,4 +26,6 @@ export {
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
+    minify,
+    flushToStyleTag,
 };

--- a/tests/no-important_test.js
+++ b/tests/no-important_test.js
@@ -41,3 +41,9 @@ describe('css', () => {
         });
     });
 });
+
+it('no-important exports match default package exports', () => {
+    const defaultExports = require('../src/index');
+    const noImportantExports = require('../src/no-important');
+    assert.hasAllKeys(noImportantExports, Object.keys(defaultExports));
+});


### PR DESCRIPTION
Added missing exports from no-important.  Added a test to verify that the exports for each package
match to avoid this in the future.  Updated chai to use a new assertion.

Fixes: #311 