### PR TITLE
Use code splitting for default and no-important builds

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,9 +35,9 @@ function distBuild(options) {
 
 const externals = new Set(Object.keys(pkg.dependencies));
 
-function standardBuilds(filename) {
+function standardBuilds() {
     return {
-        input: `src/${filename}.js`,
+        input: ['src/index.js', 'src/no-important.js'],
         external: (id /*: string */) => {
             if (externals.has(id)) {
                 return true;
@@ -47,15 +47,16 @@ function standardBuilds(filename) {
             return /^inline-style-prefixer\//.test(id);
         },
         output: [
-            { file: `lib/${filename}.js`, format: 'cjs' },
-            { file: `es/${filename}.js`, format: 'es' },
+            { dir: 'lib', format: 'cjs' },
+            { dir: 'es', format: 'es' },
         ],
         plugins: [
             babel({
                 exclude: ['node_modules/**'],
             }),
             commonjs(), // so rollup can convert node modules to ESM if needed
-        ]
+        ],
+        experimentalCodeSplitting: true,
     };
 }
 
@@ -63,6 +64,5 @@ export default [
     distBuild({ filename: 'aphrodite.umd.js', format: 'umd', sourcemap: true, minify: false }),
     distBuild({ filename: 'aphrodite.umd.min.js', format: 'umd', sourcemap: true, minify: true }),
     distBuild({ filename: 'aphrodite.js', format: 'cjs', sourcemap: false, minify: false }),
-    standardBuilds('index'),
-    standardBuilds('no-important'),
+    standardBuilds(),
 ];

--- a/src/exports.js
+++ b/src/exports.js
@@ -2,10 +2,15 @@
 import {hashString} from './util';
 import {
     injectAndGetClassName,
-    reset, startBuffering, flushToString,
-    addRenderedClassNames, getRenderedClassNames,
+    reset,
+    startBuffering,
+    flushToString,
+    flushToStyleTag,
+    addRenderedClassNames,
+    getRenderedClassNames,
     getBufferedStyles,
 } from './inject';
+import {defaultSelectorHandlers} from './generate';
 
 /* ::
 import type { SelectorHandler } from './generate.js';
@@ -132,7 +137,7 @@ const StyleSheetTestUtils = process.env.NODE_ENV === 'production'
  */
 export default function makeExports(
     useImportant /* : boolean */,
-    selectorHandlers /* : SelectorHandler[] */
+    selectorHandlers /* : SelectorHandler[] */ = defaultSelectorHandlers,
 ) {
     return {
         StyleSheet: {
@@ -158,8 +163,7 @@ export default function makeExports(
                 const extensionSelectorHandlers = extensions
                     // Pull out extensions with a selectorHandler property
                     .map(extension => extension.selectorHandler)
-                    // Remove nulls (i.e. extensions without a selectorHandler
-                    // property).
+                    // Remove nulls (i.e. extensions without a selectorHandler property).
                     .filter(handler => handler);
 
                 return makeExports(
@@ -180,5 +184,9 @@ export default function makeExports(
             return injectAndGetClassName(
                 useImportant, styleDefinitions, selectorHandlers);
         },
+
+        flushToStyleTag,
+        injectAndGetClassName,
+        defaultSelectorHandlers,
     };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,8 @@
-import {defaultSelectorHandlers} from './generate';
 import makeExports from './exports';
-import {flushToStyleTag, injectAndGetClassName} from './inject';
 
 const useImportant = true; // Add !important to all style definitions
 
-const Aphrodite = makeExports(
-    useImportant,
-    defaultSelectorHandlers
-);
+const Aphrodite = makeExports(useImportant);
 
 const {
     StyleSheet,
@@ -15,6 +10,9 @@ const {
     StyleSheetTestUtils,
     css,
     minify,
+    flushToStyleTag,
+    injectAndGetClassName,
+    defaultSelectorHandlers,
 } = Aphrodite;
 
 export {

--- a/src/no-important.js
+++ b/src/no-important.js
@@ -2,23 +2,21 @@
 // Module with the same interface as the core aphrodite module,
 // except that styles injected do not automatically have !important
 // appended to them.
-import {defaultSelectorHandlers} from './generate';
 import makeExports from './exports';
-import {flushToStyleTag, injectAndGetClassName} from './inject';
 
 const useImportant = false; // Don't add !important to style definitions
 
-const Aphrodite = makeExports(
-    useImportant,
-    defaultSelectorHandlers
-);
+const Aphrodite = makeExports(useImportant);
 
 const {
     StyleSheet,
     StyleSheetServer,
     StyleSheetTestUtils,
     css,
-    minify
+    minify,
+    flushToStyleTag,
+    injectAndGetClassName,
+    defaultSelectorHandlers,
 } = Aphrodite;
 
 export {


### PR DESCRIPTION
If two copies of Aphrodite end up being run at the same time, you can
easily encounter issues due to state stored by Aphrodite not being
shared between the multiple copies (e.g. `isBuffering`).

Since v2, when we started using rollup to build Aphrodite, this was
pretty easy to accidentally do if you weren't careful about when you
imported from `aphrodite` or `aphrodite/no-important`. This has resulted
in some issues, particularly around
react-with-styles-interface-amp-aphrodite and hypernova-amp not being
super careful about which version of aphrodite they import. One of the
recent fixes for this can be seen here:

  https://github.com/airbnb/react-with-styles-interface-amp-aphrodite/pull/8

In an effort to make this safer, I am making a small change to how we
build this library. Rollup offers an experimental code splitting mode
that allows us to keep the separate entry points and automatically
dedupe all of the shared code into a single chunk that each entry point
imports. As a result, we can provide the same API we currently do to
consumers, and avoid this issue to some extent.

The result of running this build on the es directory looks like the
following:

- chunk-957f2f88.js
- index.js
- no-important.js

and es/index.js ends up looking like:

```js
import { a as makeExports } from './chunk-957f2f88.js';
import 'string-hash';
import 'inline-style-prefixer/static/plugins/calc';
import 'inline-style-prefixer/static/plugins/crossFade';
import 'inline-style-prefixer/static/plugins/cursor';
import 'inline-style-prefixer/static/plugins/filter';
import 'inline-style-prefixer/static/plugins/flex';
import 'inline-style-prefixer/static/plugins/flexboxIE';
import 'inline-style-prefixer/static/plugins/flexboxOld';
import 'inline-style-prefixer/static/plugins/gradient';
import 'inline-style-prefixer/static/plugins/imageSet';
import 'inline-style-prefixer/static/plugins/position';
import 'inline-style-prefixer/static/plugins/sizing';
import 'inline-style-prefixer/static/plugins/transition';
import 'inline-style-prefixer/static/createPrefixer';
import 'asap';

var useImportant = true; // Add !important to all style definitions

var Aphrodite = makeExports(useImportant);

var StyleSheet = Aphrodite.StyleSheet,
    StyleSheetServer = Aphrodite.StyleSheetServer,
    StyleSheetTestUtils = Aphrodite.StyleSheetTestUtils,
    css = Aphrodite.css,
    minify = Aphrodite.minify,
    flushToStyleTag = Aphrodite.flushToStyleTag,
    injectAndGetClassName = Aphrodite.injectAndGetClassName,
    defaultSelectorHandlers = Aphrodite.defaultSelectorHandlers;

export { StyleSheet, StyleSheetServer, StyleSheetTestUtils, css, minify, flushToStyleTag, injectAndGetClassName, defaultSelectorHandlers };
```

(es/no-important.js looks almost identical)

The bulk of the library ends up in es/chunk-957f2f88.js, which should
allow the state to be consolidated in this scenario.