### PR TITLE
Enable buffer methods before needing to call StyleSheetServer.renderStatic

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {hashString} from './util';
+import { hashString } from './util';
 import {
     injectAndGetClassName,
     reset,
@@ -10,7 +10,7 @@ import {
     getRenderedClassNames,
     getBufferedStyles,
 } from './inject';
-import {defaultSelectorHandlers} from './generate';
+import { defaultSelectorHandlers } from './generate';
 
 /* ::
 import type { SelectorHandler } from './generate.js';
@@ -56,7 +56,7 @@ const StyleSheet = {
         return mappedSheetDefinition;
     },
 
-    rehydrate(renderedClassNames /* : string[] */ =[]) {
+    rehydrate(renderedClassNames /* : string[] */ = []) {
         addRenderedClassNames(renderedClassNames);
     },
 };
@@ -87,6 +87,27 @@ const StyleSheetServer = typeof window !== 'undefined'
                     renderedClassNames: getRenderedClassNames(),
                 },
             };
+        },
+        /**
+         * Prevent styles from being injected into the DOM.
+         *
+         * This is useful in situations where you'd like to test rendering UI
+         * components which use Aphrodite without any of the side-effects of
+         * Aphrodite happening.
+         *
+         * Should be paired with a subsequent call to
+         * clearBufferAndResumeStyleInjection.
+         */
+        suppressStyleInjection() {
+            reset();
+            startBuffering();
+        },
+
+        /**
+        * Opposite method of preventStyleInject.
+        */
+        clearBufferAndResumeStyleInjection() {
+            reset();
         },
     };
 

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { hashString } from './util';
+import {hashString} from './util';
 import {
     injectAndGetClassName,
     reset,
@@ -10,7 +10,7 @@ import {
     getRenderedClassNames,
     getBufferedStyles,
 } from './inject';
-import { defaultSelectorHandlers } from './generate';
+import {defaultSelectorHandlers} from './generate';
 
 /* ::
 import type { SelectorHandler } from './generate.js';
@@ -56,7 +56,7 @@ const StyleSheet = {
         return mappedSheetDefinition;
     },
 
-    rehydrate(renderedClassNames /* : string[] */ = []) {
+    rehydrate(renderedClassNames /* : string[] */ =[]) {
         addRenderedClassNames(renderedClassNames);
     },
 };
@@ -91,9 +91,8 @@ const StyleSheetServer = typeof window !== 'undefined'
         /**
          * Prevent styles from being injected into the DOM.
          *
-         * This is useful in situations where you'd like to test rendering UI
-         * components which use Aphrodite without any of the side-effects of
-         * Aphrodite happening.
+         * This is useful in situations where you do not have an available DOM
+         * but are still considering walking the tree without calling a renderFunc
          *
          * Should be paired with a subsequent call to
          * clearBufferAndResumeStyleInjection.
@@ -104,7 +103,7 @@ const StyleSheetServer = typeof window !== 'undefined'
         },
 
         /**
-        * Opposite method of preventStyleInject.
+        * Opposite method of suppressStyleInjection.
         */
         clearBufferAndResumeStyleInjection() {
             reset();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,12 +33,12 @@ export interface StyleSheetStatic {
      */
     create<T extends StyleDeclaration<T>>(
         styles: T
-    ): {[K in keyof T]: StyleDeclarationValue };
+    ): { [K in keyof T]: StyleDeclarationValue };
     /**
      * Rehydrate class names from server renderer
      */
     rehydrate(renderedClassNames: string[]): void;
-    
+
     extend(extensions: Extension[]): Exports;
 }
 
@@ -68,6 +68,21 @@ interface StaticRendererResult {
  */
 interface StyleSheetServerStatic {
     renderStatic(renderFunc: () => string): StaticRendererResult;
+    /**
+     * Prevent styles from being injected into the DOM.
+     *
+     * This is useful in situations where you'd like to test rendering UI
+     * components which use Aphrodite without any of the side-effects of
+     * Aphrodite happening.
+     *
+     * Should be paired with a subsequent call to
+     * clearBufferAndResumeStyleInjection.
+     */
+    suppressStyleInjection(): void;
+    /**
+     * Opposite method of suppressStyleInjection.
+     */
+    clearBufferAndResumeStyleInjection(): void;
 }
 
 export var StyleSheetServer: StyleSheetServerStatic;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,12 +33,12 @@ export interface StyleSheetStatic {
      */
     create<T extends StyleDeclaration<T>>(
         styles: T
-    ): { [K in keyof T]: StyleDeclarationValue };
+    ): {[K in keyof T]: StyleDeclarationValue };
     /**
      * Rehydrate class names from server renderer
      */
     rehydrate(renderedClassNames: string[]): void;
-
+    
     extend(extensions: Extension[]): Exports;
 }
 
@@ -71,9 +71,8 @@ interface StyleSheetServerStatic {
     /**
      * Prevent styles from being injected into the DOM.
      *
-     * This is useful in situations where you'd like to test rendering UI
-     * components which use Aphrodite without any of the side-effects of
-     * Aphrodite happening.
+     * This is useful in situations where you do not have an available DOM
+     * but are still considering walking the tree without calling a renderFunc
      *
      * Should be paired with a subsequent call to
      * clearBufferAndResumeStyleInjection.


### PR DESCRIPTION
Currently, Aphrodite assumes that it is the first server-side module to render the tree, but 
since `StyleSheetServer.renderStatic` expects a string as return value, it eliminates any possibility of walking the reference with another module.

This PR borrows some of the TestUtils functions to allow a, albeit a bit clunky, method of avoiding having to append classes to the DOM while walking an existing reference to a tree.