### PR TITLE
--save no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Support for colocating your styles with your JavaScript component.
 Aphrodite is distributed via [npm](https://www.npmjs.com/):
 
 ```
-npm install --save aphrodite
+npm install aphrodite
 ```
 
 # API


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), so `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now