### PR TITLE
Clearer error message

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -243,6 +243,9 @@ export const addRenderedClassNames = (classNames /* : string[] */) => {
     });
 };
 
+const isValidStyleDefinition = (def /* : Object */) =>
+  "_definition" in def && "_name" in def && "_len" in def;
+
 const processStyleDefinitions = (
     styleDefinitions /* : any[] */,
     classNameBits /* : string[] */,
@@ -261,10 +264,12 @@ const processStyleDefinitions = (
                     definitionBits,
                     length,
                 );
-            } else {
+            } else if (isValidStyleDefinition(styleDefinitions[i])) {
                 classNameBits.push(styleDefinitions[i]._name);
                 definitionBits.push(styleDefinitions[i]._definition);
                 length += styleDefinitions[i]._len;
+            } else {
+                throw new Error("Invalid Style Definition: Styles should be defined using the StyleSheet.create method.")
             }
         }
     }

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -143,6 +143,10 @@ describe('css', () => {
             done();
         });
     });
+
+    it("throws a useful error for invalid arguments", () => {
+        assert.throws(() => css({ color: "red" }), "Invalid Style Definition");
+    });
 });
 
 describe('StyleSheet.create', () => {

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -143,10 +143,6 @@ describe('css', () => {
             done();
         });
     });
-
-    it("throws a useful error for invalid arguments", () => {
-        assert.throws(() => css({ color: "red" }), "Invalid Style Definition");
-    });
 });
 
 describe('StyleSheet.create', () => {


### PR DESCRIPTION
closes #265 

Add a more explicit error message when someone tries to pass a plain object instead of a stylesheet into the `css()` method. 

Note: My editor went crazy with the double quotes. Let me know if you would like me to switch them back! 