### PR TITLE
Update inject.js

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -33,8 +33,6 @@ const injectStyleTag = (cssRules /* : string[] */) => {
             // http://stackoverflow.com/questions/524696/how-to-create-a-style-tag-with-javascript
             const head = document.head || document.getElementsByTagName('head')[0];
             styleTag = document.createElement('style');
-
-            styleTag.type = 'text/css';
             styleTag.setAttribute("data-aphrodite", "");
             head.appendChild(styleTag);
         }


### PR DESCRIPTION
Based on the HTML 5 definitions, the type attribute is not required on the style tags any more.

https://www.w3schools.com/tags/att_style_type.asp

`In HTML5, the type attribute is no longer required for CSS. The default value is "text/css".`

Best,
Istvan