### PR TITLE
Bump up inline-style-prefixer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "asap": "^2.0.3",
-    "inline-style-prefixer": "^4.0.2",
+    "inline-style-prefixer": "^5.0.4",
     "string-hash": "^1.1.3"
   },
   "tonicExampleFilename": "examples/runkit.js",

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,5 +1,5 @@
 /* @flow */
-import createPrefixer from 'inline-style-prefixer/static/createPrefixer';
+import { createPrefixer } from 'inline-style-prefixer';
 import staticData from '../lib/staticPrefixData';
 
 import OrderedElements from './ordered-elements';

--- a/tools/generate_prefixer_data.js
+++ b/tools/generate_prefixer_data.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const generateData = require("inline-style-prefixer/generator");
+const generateData = require("inline-style-prefixer/lib/generator").default;
 const mkdirp = require("mkdirp");
 
 // These versions are the versions that were supported by version 2 of
@@ -22,6 +22,5 @@ const browserList = {
 
 mkdirp(`${__dirname}/../lib`);
 generateData(browserList, {
-    staticPath: `${__dirname}/../lib/staticPrefixData.js`,
-    compatibility: true,
+    path: `${__dirname}/../lib/staticPrefixData.js`,
 });


### PR DESCRIPTION
This PR bumps the version of `inline-style-prefixer` up to 5.0.4 so that Aphrodite has the css logical plugin.

The imports in `inline-style-prefixer` changed from versions 4 to 5, so this PR also updates some of the import paths, and removes the `compatibility: true` option in `generateData`, which determined whether the plugin data generated used ES5 or ES2015 imports.