### PR TITLE
Verify IE10 support for flex styles

### DIFF
--- a/tests/generate_test.js
+++ b/tests/generate_test.js
@@ -376,6 +376,16 @@ ${formatStyles(actual)}
       '}');
     });
 
+    it('correctly prefixes flex properties for IE10 support', () => {
+        assertCSS('.foo', [{
+            'flex': 'auto'
+        }], '.foo{' +
+          '-webkit-flex:auto !important;' +
+          '-ms-flex:1 1 auto !important;' +
+          'flex:auto !important;' +
+      '}');
+    });
+
     // TODO(emily): In the future, filter out null values.
     it('handles nullish values', () => {
         assertCSS('.foo', [{


### PR DESCRIPTION
This adds support for expanding some flex values in https://github.com/rofrischmann/inline-style-prefixer/pull/166 and bumps the package to the latest version and adds a test to verify we're generating those values. We pull in a few other minor fixes from that project as well if you want to look at the changelog below.

It's worthwhile to note that the major version bump required a few other changes. Primarily, there is no dynamic prefixer any longer, and this project has used the static one all along, so mainly just paths needed to be updated.

The other change I needed was to remove the `compatibility` flag when generating the static data, although I'm not sure that wasn't due to our own tooling. The generated file now looks something like:

```javascript
import backgroundClip from 'inline-style-prefixer/lib/plugins/backgroundClip'
import calc from 'inline-style-prefixer/lib/plugins/calc'

// ...

export default {
  plugins: [backgroundClip, /* ... */],
  prefixMap: {"transform":wms, /* ... */}
}
```
Whereas with the compatibility flag it would of generated require statements that wouldn't of resolved without adding a `.default` to them.

https://github.com/rofrischmann/inline-style-prefixer/blob/master/CHANGELOG.md#504