### PR TITLE
Use deep import for inline-style-prefixer

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { createPrefixer } from 'inline-style-prefixer';
+import createPrefixer from 'inline-style-prefixer/lib/createPrefixer';
 import staticData from '../lib/staticPrefixData';
 
 import OrderedElements from './ordered-elements';


### PR DESCRIPTION
After updating to 2.3.0, I noticed a large bundle size increase. I
believe this is due to switching this from a deep import to a named
import, so we were duplicating a bunch of code (the named import used
the es build, which brought in the es plugins, but our generated data
brought in the lib plugins).

As a quick fix, I think we can bring bundle sizes back down by using a
deep import here again.