### PR TITLE
fix no-important entry resolve

### DIFF
--- a/no-important.d.ts
+++ b/no-important.d.ts
@@ -1,1 +1,0 @@
-export * from './typings';

--- a/no-important.js
+++ b/no-important.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/no-important.js');

--- a/no-important/package.json
+++ b/no-important/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../lib/no-important.js",
+  "module": "../es/no-important.js",
+  "typings": "../typings/index.d.ts"
+}


### PR DESCRIPTION
If I use `import {css} from 'aphrodite/no-important'` in a ES module file, bundle tools like Rollup will resolve `aphrodite/no-important` to `node_modules/aphrodite/no-important.js` and then `node_modules/aphrodite/lib/no-important.js` which is not a ES module. To make things worse, `rollup-plugin-commonjs` cannot resolve named import (`import {X} from 'x'`) for CommonJS modules.

A workaround is to use `import {css} from 'aphrodite/es/no-important'`. However this doesn't work for 'universal' code because ES module cannot be resolved in Node environment without being transpiled.

This change will let module resolver find `package.json` file in `node_modules/aphrodite/no-important` directory.