### PR TITLE
Make parameter typings for StyleSheet.create more typed

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -31,8 +31,8 @@ export interface StyleSheetStatic {
     /**
      * Create style sheet
      */
-    create<T extends StyleDeclaration<T>>(
-        styles: T
+    create<T>(
+        styles: StyleDeclaration<T>
     ): {[K in keyof T]: StyleDeclarationValue };
     /**
      * Rehydrate class names from server renderer


### PR DESCRIPTION
This is a small change in the typings, to make the `StyleSheet.create(...)` parameters more typed, and offer better intellisense/autocompletion.

**before:**

![screencast_before](https://user-images.githubusercontent.com/17981138/56478825-3654e380-64b2-11e9-9d50-a0a2a4b789e9.gif)

**after:**

![screencast_after](https://user-images.githubusercontent.com/17981138/56478772-f988ec80-64b1-11e9-83d1-d572b76994b3.gif)

---

The only thing I couldn't figure out is how to get the intellisense for pseudo selectors inside a mediaquery. Although you can use it without any errors, it's just the intellisense that is not complete. Anyone any ideas?