### PR TITLE
Add Typescript export for flushToStyleTag

### DIFF
--- a/tests-ts/aphrodite_test.ts
+++ b/tests-ts/aphrodite_test.ts
@@ -1,4 +1,4 @@
-import { css, minify, StyleSheet, StyleSheetServer, StyleSheetTestUtils } from '../typings';
+import { css, minify, StyleSheet, StyleSheetServer, StyleSheetTestUtils, flushToStyleTag } from '../typings';
 
 // StyleSheet
 const withNumberOrString = StyleSheet.create({
@@ -59,3 +59,6 @@ serverResult.html.toLowerCase();
 // minify
 minify(true);
 minify(false);
+
+// flushToStyleTag
+flushToStyleTag();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -108,6 +108,8 @@ export interface SelectorHandler {
 export interface Extension {
     selectorHandler?: SelectorHandler;
 }
+                             
+export function flushToStyleTag(): void;
 
 /**
  * Calling StyleSheet.extend() returns an object with each of the exported
@@ -118,4 +120,5 @@ interface Exports {
     StyleSheet: StyleSheetStatic;
     StyleSheetServer: StyleSheetServerStatic;
     StyleSheetTestUtils: StyleSheetTestUtilsStatic;
+    flushToStyleTag(): void;
 }


### PR DESCRIPTION
Fixes #378 

- Adds an export in the typings file for the flushToStyleTag function 
- Adds a test for the flushToStyleTag function's existence 