### PR TITLE
Allow already injected to be reset

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -3,6 +3,7 @@ import {hashString} from './util';
 import {
     injectAndGetClassName,
     reset,
+    resetInjected,
     startBuffering,
     flushToString,
     flushToStyleTag,
@@ -188,5 +189,7 @@ export default function makeExports(
         flushToStyleTag,
         injectAndGetClassName,
         defaultSelectorHandlers,
+        reset,
+        resetInjected,
     };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ const {
     flushToStyleTag,
     injectAndGetClassName,
     defaultSelectorHandlers,
+    reset,
+    resetInjected,
 } = Aphrodite;
 
 export {
@@ -24,4 +26,6 @@ export {
     flushToStyleTag,
     injectAndGetClassName,
     defaultSelectorHandlers,
+    reset,
+    resetInjected,
 };

--- a/src/inject.js
+++ b/src/inject.js
@@ -203,9 +203,13 @@ export const reset = () => {
     styleTag = null;
 };
 
+export const resetInjected = (key /* : string */) => {
+  delete alreadyInjected[key];
+};
+
 export const getBufferedStyles = () => {
     return injectionBuffer;
-}
+};
 
 export const startBuffering = () => {
     if (isBuffering) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -38,7 +38,7 @@ export interface StyleSheetStatic {
      * Rehydrate class names from server renderer
      */
     rehydrate(renderedClassNames: string[]): void;
-    
+
     extend(extensions: Extension[]): Exports;
 }
 
@@ -54,6 +54,12 @@ export function css(...styles: CSSInputTypes[]): string;
  *  Override Aphrodite minifying styles to hashes in production
  */
 export function minify(shouldMinify: boolean): void;
+
+export function flushToStyleTag(): void;
+
+export function reset(): void;
+
+export function resetInjected(key: string): void;
 
 interface StaticRendererResult {
     html: string;


### PR DESCRIPTION
to: @lencioni 

We have some logic in our app that deletes injected CSS rules (mostly global styles). This works great.

However, once the styles are regenerate and attempt to inject again, they will not as Aphrodite blocks the injection because the previous key is set to `alreadyInjected`. https://github.com/Khan/aphrodite/blob/master/src/inject.js#L159

This PR adds a minor function called `resetInjected` to clear this cache. I also went ahead and exported `reset` since it may also be useful.
