### PR TITLE
improve npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,23 @@
+// dirs
 .nyc_output
+examples
+src
+tests
+tests-ts
+tools
+
+// files
+.arcconfig
+.arclint
+.babelrc
+.editorconfig
+.eslintcache
+.eslintignore
+.flowconfig
+.gitattributes
+.travis.yml
+benchmark.html
+rollup.config.js
+tsconfig.json
+tslint.json
+


### PR DESCRIPTION
Update `.npmignore` file to not publish files and dirs that aren't used by consumers. This simplified the distributed binaries but the main motivation for this change is that `.flowconfig` is included when aphrodite is published. Which if I browse the files within node_modules, flow server will crash because it detects multiple upstream flow configs.

@lencioni @jlfwong 